### PR TITLE
Update yarapython.rst

### DIFF
--- a/docs/yarapython.rst
+++ b/docs/yarapython.rst
@@ -123,9 +123,8 @@ But you can also apply the rules to a Python string:
 
 .. code-block:: python
 
-  f = fopen('/foo/bar/my_file', 'rb')
-
-  matches = rules.match(data=f.read())
+  with open('/foo/bar/my_file', 'rb') as f:
+    matches = rules.match(data=f.read())
 
 Or to a running process:
 


### PR DESCRIPTION
There is no fopen() in python. The suggested method is more pythonic.