### PR TITLE
pe_utils.c: Add missing include for defining struct tm

### DIFF
--- a/libyara/modules/pe_utils.c
+++ b/libyara/modules/pe_utils.c
@@ -2,6 +2,8 @@
 
 #if !HAVE_TIMEGM
 
+#include <time.h>
+
 static int is_leap(
     unsigned int year)
 {


### PR DESCRIPTION
Build failed trying to cross-compile using the MinGW
toolchain. (mingw-w64-tools 3.2.0-2 on Debian jessie/sid)