### PR TITLE
yara-python/tests.py: Add missing f.close() to avoid warning

### DIFF
--- a/yara-python/tests.py
+++ b/yara-python/tests.py
@@ -641,6 +641,7 @@ class TestYara(unittest.TestCase):
         f.seek(0)
 
         r = yara.compile(file=f)
+        f.close()
         self.assertTrue(r.match(data=PE32_FILE))
 
     def testCompileFiles(self):


### PR DESCRIPTION
With Python 3.4, I got:

    ResourceWarning: unclosed file <_io.TextIOWrapper name=4 mode='wt' encoding='UTF-8'>