### PR TITLE
Fix unmapped memory access in PE parser

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -633,10 +633,8 @@ void pe_parse_version_info(
   if (!struct_fits_in_pe(pe, string_file_info, VERSION_INFO))
     return;
 
-  if (!fits_in_pe(pe, string_file_info, sizeof("StringFileInfo")))
-    return;
-
-  while(strcmp_w(string_file_info->Key, "StringFileInfo") == 0)
+  while(fits_in_pe(pe, string_file_info, sizeof("StringFileInfo")) &&
+        strcmp_w(string_file_info->Key, "StringFileInfo") == 0)
   {
     PVERSION_INFO string_table = ADD_OFFSET(
         string_file_info,


### PR DESCRIPTION
This commit fixes a crash that takes place when trying to access an invalid memory location in PE parser.

A poc (proof of crash) file can be provided if necessary.

In addition, I noticed that in this source file, "fits_in_pe" check is always done over the struct and not the char pointer contained in it, even when the string is used later:

```
if (!fits_in_pe(pe, version_info, sizeof("VS_VERSION_INFO")))
    return;

  if (strcmp_w(version_info->Key, "VS_VERSION_INFO") != 0)
    return;
```

Also as strcmp_w is a wide string, sizeof should be multiplied by two, right?

These two points could open the door to more crashes.

Cheers!