### PR TITLE
PE module: Fix unchecked access to version info buffers

### DIFF
--- a/libyara/include/yara/strutils.h
+++ b/libyara/include/yara/strutils.h
@@ -59,8 +59,9 @@ void* memmem(
 #endif
 
 
-int strlen_w(
-    const char* w_str);
+int strnlen_w(
+    const char* w_str,
+    size_t maxbytes);
 
 
 int strcmp_w(

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -619,7 +619,7 @@ void pe_parse_version_info(
 
   version_info = (PVERSION_INFO) (pe->data + version_info_offset);
 
-  if (!fits_in_pe(pe, version_info->Key, sizeof("VS_VERSION_INFO")))
+  if (!fits_in_pe(pe, version_info->Key, sizeof("VS_VERSION_INFO") * 2))
     return;
 
   if (strcmp_w(version_info->Key, "VS_VERSION_INFO") != 0)
@@ -627,7 +627,7 @@ void pe_parse_version_info(
 
   string_file_info = ADD_OFFSET(version_info, sizeof(VERSION_INFO) + 86);
 
-  while(fits_in_pe(pe, string_file_info->Key, sizeof("StringFileInfo")) &&
+  while(fits_in_pe(pe, string_file_info->Key, sizeof("StringFileInfo") * 2) &&
       strcmp_w(string_file_info->Key, "StringFileInfo") == 0)
   {
     PVERSION_INFO string_table = ADD_OFFSET(

--- a/libyara/strutils.c
+++ b/libyara/strutils.c
@@ -153,15 +153,17 @@ size_t strlcat(
 #endif
 
 
-int strlen_w(
-    const char* w_str)
+int strnlen_w(
+    const char* w_str,
+    size_t maxbytes)
 {
   int len = 0;
 
-  while (*w_str != 0)
+  while (maxbytes >= 2 && (w_str[0] || w_str[1]))
   {
     w_str += 2;
     len += 1;
+    maxbytes -= 2;
   }
 
   return len;

--- a/libyara/strutils.c
+++ b/libyara/strutils.c
@@ -174,19 +174,17 @@ int strcmp_w(
     const char* w_str,
     const char* str)
 {
-  while (*w_str != 0 && *str != 0 && *w_str == *str)
+  while (*str != 0 && w_str[0] == *str && w_str[1] == 0)
   {
     w_str += 2;
     str += 1;
   }
 
-  if (*w_str == *str)
-    return 0;
-
-  if (*w_str > *str)
+  // Higher-order byte of wide char non-zero? -> w_str is larger than str
+  if (w_str[1] != 0)
     return 1;
 
-  return -1;
+  return w_str[0] - *str;
 }
 
 


### PR DESCRIPTION
Fixes crash (at least on Windows) for
https://www.virustotal.com/en/file/a906103c7b972e7adf8ea9c736ca44373949480576d7fc6042c495c47e9bbff5/analysis/1423694573/
and adds additional safety for other cases like unterminated keys