### PR TITLE
Variable redefinition error fixed

### DIFF
--- a/libyara/modules/math.c
+++ b/libyara/modules/math.c
@@ -42,7 +42,9 @@ define_function(string_entropy)
   if (data == NULL)
     return_float(UNDEFINED);
 
-  for (int i = 0; i < s->length; i++)
+  int i;
+
+  for (i = 0; i < s->length; i++)
   {
     uint8_t c = s->c_string[i];
     data[c] += 1;
@@ -50,7 +52,7 @@ define_function(string_entropy)
 
   double entropy = 0.0;
 
-  for (int i = 0; i < 256; i++)
+  for (i = 0; i < 256; i++)
   {
     if (data[i] != 0)
     {

--- a/yara.c
+++ b/yara.c
@@ -1014,7 +1014,9 @@ int main(
     thread_args.rules = rules;
     thread_args.start_time = start_time;
 
-    for (int i = 0; i < threads; i++)
+    int i;
+
+    for (i = 0; i < threads; i++)
     {
       if (create_thread(&thread[i], scanning_thread, (void*) &thread_args))
       {
@@ -1033,7 +1035,7 @@ int main(
     file_queue_finish();
 
     // Wait for scan threads to finish
-    for (int i = 0; i < threads; i++)
+    for (i = 0; i < threads; i++)
       thread_join(&thread[i]);
 
     file_queue_destroy();


### PR DESCRIPTION
This fixes a compilation error with clang:

    $ make install
    (…)
    libtool: compile:  clang -DHAVE_CONFIG_H -I. -I.. -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE -c modules/math.c  -fno-common -DPIC -o modules/.libs/math.o
    modules/math.c:53:12: error: redefinition of 'i'
      for (int i = 0; i < 256; i++)
               ^
    modules/math.c:45:12: note: previous definition is here
      for (int i = 0; i < s->length; i++)
               ^
    1 error generated.

---

I used:

```
$ ./bootstrap.sh
$ ./configure --disable-silent-rules --disable-dependency-tracking --prefix=/usr/local/Cellar/yara/3.3.0
(…)
$ make install
Making install in libyara
/bin/sh ../libtool  --tag=CC   --mode=compile clang -DHAVE_CONFIG_H -I. -I..    -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE  -c -o modules/tests.lo modules/tests.c
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I.. -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE -c modules/tests.c  -fno-common -DPIC -o modules/.libs/tests.o
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I.. -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE -c modules/tests.c -o modules/tests.o >/dev/null 2>&1
/bin/sh ../libtool  --tag=CC   --mode=compile clang -DHAVE_CONFIG_H -I. -I..    -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE  -c -o modules/pe.lo modules/pe.c
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I.. -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE -c modules/pe.c  -fno-common -DPIC -o modules/.libs/pe.o
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I.. -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE -c modules/pe.c -o modules/pe.o >/dev/null 2>&1
/bin/sh ../libtool  --tag=CC   --mode=compile clang -DHAVE_CONFIG_H -I. -I..    -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE  -c -o modules/elf.lo modules/elf.c
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I.. -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE -c modules/elf.c  -fno-common -DPIC -o modules/.libs/elf.o
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I.. -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE -c modules/elf.c -o modules/elf.o >/dev/null 2>&1
/bin/sh ../libtool  --tag=CC   --mode=compile clang -DHAVE_CONFIG_H -I. -I..    -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE  -c -o modules/math.lo modules/math.c
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I.. -O3 -Wall -Wno-deprecated-declarations -std=gnu99 -I./include -std=gnu89 -D_THREAD_SAFE -c modules/math.c  -fno-common -DPIC -o modules/.libs/math.o
modules/math.c:53:12: error: redefinition of 'i'
  for (int i = 0; i < 256; i++)
           ^
modules/math.c:45:12: note: previous definition is here
  for (int i = 0; i < s->length; i++)
           ^
1 error generated.
make[1]: *** [modules/math.lo] Error 1
make: *** [install-recursive] Error 1
```

With Clang 6.0 build 600 on 10.10.2-x86_64.