### PR TITLE
Move the stack used by exec.c into YARA_CONTEXT

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -32,22 +32,11 @@ limitations under the License.
 
 #include <yara.h>
 
-
-#define STACK_SIZE 16384
 #define MEM_SIZE   MAX_LOOP_NESTING * LOOP_LOCAL_VARS
-
-union STACK_ITEM {
-  int64_t i;
-  double d;
-  void* p;
-  YR_OBJECT* o;
-  YR_STRING* s;
-  SIZED_STRING* ss;
-};
 
 #define push(x)  \
     do { \
-      if (sp < STACK_SIZE) stack[sp++] = (x); \
+      if (sp < YR_SCAN_STACK_SIZE) stack[sp++] = (x); \
       else return ERROR_EXEC_STACK_OVERFLOW; \
     } while(0)
 
@@ -157,7 +146,7 @@ int yr_execute_code(
   int32_t sp = 0;
   uint8_t* ip = rules->code_start;
 
-  union STACK_ITEM stack[STACK_SIZE];
+  union STACK_ITEM *stack = context->scan_stack;
   union STACK_ITEM r1;
   union STACK_ITEM r2;
   union STACK_ITEM r3;

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -44,5 +44,7 @@ limitations under the License.
 #define STRING_CHAINING_THRESHOLD       200
 #define LEX_BUF_SIZE                    1024
 
+/* Stack size pulled from exec.c */
+#define YR_SCAN_STACK_SIZE              16384
 
 #endif

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <yara/re.h>
 #include <yara/limits.h>
 #include <yara/hash.h>
+#include <yara/sizedstr.h>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -374,22 +375,6 @@ typedef int (*YR_CALLBACK_FUNC)(
     void* user_data);
 
 
-typedef struct _YR_SCAN_CONTEXT
-{
-  uint64_t  file_size;
-  uint64_t  entry_point;
-
-  int flags;
-  void* user_data;
-
-  YR_MEMORY_BLOCK*  mem_block;
-  YR_HASH_TABLE*  objects_table;
-  YR_CALLBACK_FUNC  callback;
-
-} YR_SCAN_CONTEXT;
-
-
-
 #define OBJECT_COMMON_FIELDS \
     int8_t type; \
     const char* identifier; \
@@ -402,6 +387,33 @@ typedef struct _YR_OBJECT
   OBJECT_COMMON_FIELDS
 
 } YR_OBJECT;
+
+
+union STACK_ITEM {
+  int64_t i;
+  double d;
+  void* p;
+  YR_OBJECT* o;
+  YR_STRING* s;
+  SIZED_STRING* ss;
+};
+
+
+typedef struct _YR_SCAN_CONTEXT
+{
+  uint64_t  file_size;
+  uint64_t  entry_point;
+
+  int flags;
+  void* user_data;
+
+  YR_MEMORY_BLOCK*  mem_block;
+  YR_HASH_TABLE*  objects_table;
+  YR_CALLBACK_FUNC  callback;
+
+  union STACK_ITEM *scan_stack;
+
+} YR_SCAN_CONTEXT;
 
 
 typedef struct _YR_OBJECT_INTEGER

--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -360,6 +360,12 @@ YR_API int yr_rules_scan_mem_blocks(
 
   yr_set_tidx(tidx);
 
+  /* Allocate the stack for the scanner in exec.c:yr_execute_code. */
+  context.scan_stack = yr_calloc(YR_SCAN_STACK_SIZE, sizeof(union STACK_ITEM));
+
+  if (context.scan_stack == NULL)
+    goto _exit;
+
   result = yr_arena_create(1024, 0, &matches_arena);
 
   if (result != ERROR_SUCCESS)
@@ -489,6 +495,9 @@ _exit:
   _yr_rules_lock(rules);
   rules->tidx_mask &= ~(1 << tidx);
   _yr_rules_unlock(rules);
+
+  if (context.scan_stack != NULL)
+     yr_free(context.scan_stack);
 
   yr_set_tidx(-1);
 


### PR DESCRIPTION
Modify the behavior so that it allocates space from heap memory, providing options for larger stack size allocation. Also moved the stack size #define into yara/limits.h