### PR TITLE
Do not recompute match chain lengths

### DIFF
--- a/libyara/scan.c
+++ b/libyara/scan.c
@@ -327,12 +327,13 @@ void _yr_scan_update_match_chain_length(
   YR_MATCH* match;
   size_t ending_offset;
 
+  if (match_to_update->chain_length == chain_length)
+    return;
   match_to_update->chain_length = chain_length;
 
-  if (string->chained_to != NULL)
-    match = string->chained_to->unconfirmed_matches[tidx].head;
-  else
-    match = NULL;
+  if (string->chained_to == NULL)
+    return;
+  match = string->chained_to->unconfirmed_matches[tidx].head;
 
   while (match != NULL)
   {


### PR DESCRIPTION
Hi Victor,

Please merge this patch that terminates the recursion early in _yr_scan_update_match_chain_length() if the match is already updated. This avoids an exponential blow-up in that function when scanning for long hex signatures with wildcards.

Cheers,

Christian