### PR TITLE
PE module: Add lower boundary to access bounds check.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -92,7 +92,8 @@ limitations under the License.
 
 
 #define fits_in_pe(pe, pointer, size) \
-    ((uint8_t*)(pointer) + size <= pe->data + pe->data_size)
+    (pe->data <= (uint8_t*)(pointer) && \
+     (uint8_t*)(pointer) + size <= pe->data + pe->data_size)
 
 
 #define struct_fits_in_pe(pe, pointer, struct_type) \


### PR DESCRIPTION
On a 32-bit Linux system, I witnessed a crash around
pe_parse_import_descriptor() (pe.c:867) because strndup() wanted to
read from an invalid address that was the result from an integer
overflow and turned out to be less than pe->data.

Since that overflow does not occur on 64-bit systems, they are not
affected.