### PR TITLE
Increase limits and dynamically allocate stack.

### DIFF
--- a/libyara/exec.c
+++ b/libyara/exec.c
@@ -29,6 +29,7 @@ limitations under the License.
 #include <yara/re.h>
 #include <yara/strutils.h>
 #include <yara/utils.h>
+#include <yara/mem.h>
 
 #include <yara.h>
 
@@ -157,7 +158,7 @@ int yr_execute_code(
   int32_t sp = 0;
   uint8_t* ip = rules->code_start;
 
-  union STACK_ITEM stack[STACK_SIZE];
+  union STACK_ITEM *stack;
   union STACK_ITEM r1;
   union STACK_ITEM r2;
   union STACK_ITEM r3;
@@ -180,6 +181,10 @@ int yr_execute_code(
   clock_t start = clock();
   #endif
 
+  stack = (union STACK_ITEM *) yr_malloc(STACK_SIZE * sizeof(union STACK_ITEM));
+  if (stack == NULL)
+    return ERROR_INSUFICIENT_MEMORY;
+
   while(1)
   {
     switch(*ip)
@@ -188,6 +193,7 @@ int yr_execute_code(
         // When the halt instruction is reached the stack
         // should be empty.
         assert(sp == 0);
+        yr_free(stack);
         return ERROR_SUCCESS;
 
       case OP_PUSH:
@@ -1075,6 +1081,6 @@ int yr_execute_code(
 
   // After executing the code the stack should be empty.
   assert(sp == 0);
-
+  yr_free(stack);
   return ERROR_SUCCESS;
 }

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -42,7 +42,7 @@ limitations under the License.
 
 #define LOOP_LOCAL_VARS                 4
 #define STRING_CHAINING_THRESHOLD       200
-#define LEX_BUF_SIZE                    1024
+#define LEX_BUF_SIZE                    8192
 
 
 #endif

--- a/libyara/re.c
+++ b/libyara/re.c
@@ -46,7 +46,7 @@ order to avoid confusion with operating system threads.
 
 
 #define RE_MAX_STACK      1024  // Maxium stack size for regexp evaluation
-#define RE_MAX_CODE_SIZE  16384 // Maximum code size for a compiled regexp
+#define RE_MAX_CODE_SIZE  32768 // Maximum code size for a compiled regexp
 #define RE_SCAN_LIMIT     4096  // Maximum input size scanned by yr_re_exec
 
 


### PR DESCRIPTION
Limits changes for long yara files and complex regexps.
Dynamically allocate stack in exec.c to reduce stack usage.