### PR TITLE
Implement NOMINMAX.

### DIFF
--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -36,6 +36,7 @@ limitations under the License.
 #define YR_API
 #endif
 
+#ifndef NOMINMAX
 #ifndef min
 #define min(x, y) ((x < y) ? (x) : (y))
 #endif
@@ -43,6 +44,7 @@ limitations under the License.
 #ifndef max
 #define max(x, y) ((x > y) ? (x) : (y))
 #endif
+#endif /* NOMINMAX */
 
 
 #define PTR_TO_UINT64(x)  ((uint64_t) (size_t) x)


### PR DESCRIPTION
As discussed in #260 implement a NOMINMAX check around the min and max
macros.

This allows c++ code which includes yara.h to #define NOMINMAX before
the include and #undef it after.