### PR TITLE
Fix regression in pe_collect_resources().

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -707,7 +707,7 @@ int pe_collect_resources(
   DWORD length;
   size_t offset = pe_rva_to_offset(pe, rsrc_data->OffsetToData);
 
-  if (offset == 0 || !fits_in_pe(pe, offset, rsrc_data->Size))
+  if (offset == 0 || !fits_in_pe(pe, pe->data + offset, rsrc_data->Size))
     return RESOURCE_CALLBACK_CONTINUE;
 
   set_integer(


### PR DESCRIPTION
It appears that after 223daaf9c4d335b87805654466fba32f3988ad5a no
resources were properly collected. Fix it by passing in the correct
offset, which is pe->data + offset.