### PR TITLE
Fixed bison compiling error, version error and added access to segments from elf module

### DIFF
--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -226,7 +226,7 @@ rule
 
         ERROR_IF(rule == NULL);
 
-        $$ = rule;
+        $<rule>$ = rule;
       }
       condition '}'
       {

--- a/libyara/include/yara/elf.h
+++ b/libyara/include/yara/elf.h
@@ -91,7 +91,8 @@ typedef uint64_t elf64_xword_t;
 #define ELF_PT_SHLIB         5     // Reserved, unspecified semantics
 #define ELF_PT_PHDR          6     // Location and size of program header table
 #define ELF_PT_TLS           7     // Thread-Local Storage 
-#define ELF_PT_GNU_EH_FRAME  0x6474e550 
+#define ELF_PT_GNU_EH_FRAME  0x6474e550
+#define ELF_PT_GNU_STACK     0x6474e551
  
 #define ELF_PF_X             0x1   // Segment is executable
 #define ELF_PF_W             0x2   // Segment is writable

--- a/libyara/include/yara/elf.h
+++ b/libyara/include/yara/elf.h
@@ -83,6 +83,20 @@ typedef uint64_t elf64_xword_t;
 #define ELF_SHF_ALLOC        0x2   // Section is present during execution
 #define ELF_SHF_EXECINSTR    0x4   // Section contains executable instructions
 
+#define ELF_PT_NULL          0     // The array element is unused
+#define ELF_PT_LOAD          1     // Loadable segment    
+#define ELF_PT_DYNAMIC       2     // Segment contains dynamic linking info
+#define ELF_PT_INTERP        3     // Contains interpreter pathname
+#define ELF_PT_NOTE          4     // Location & size of auxiliary info
+#define ELF_PT_SHLIB         5     // Reserved, unspecified semantics
+#define ELF_PT_PHDR          6     // Location and size of program header table
+#define ELF_PT_TLS           7     // Thread-Local Storage 
+#define ELF_PT_GNU_EH_FRAME  0x6474e550 
+ 
+#define ELF_PF_X             0x1   // Segment is executable
+#define ELF_PF_W             0x2   // Segment is writable
+#define ELF_PF_R             0x4   // Segment is readable
+
 #pragma pack(push,1)
 
 typedef struct

--- a/windows/include/config.h
+++ b/windows/include/config.h
@@ -9,10 +9,10 @@
 #define PACKAGE_NAME "yara"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "yara 3.2.0"
+#define PACKAGE_STRING "yara 3.3.0"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.2.0"
+#define PACKAGE_VERSION "3.3.0"
 
 /* Version number of package */
-#define VERSION "3.2.0"
+#define VERSION "3.3.0"


### PR DESCRIPTION
Linux localhost 3.17.7-gentoo #1 SMP Wed Jan 7 09:38:05 CET 2015 i686 Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz GenuineIntel GNU/Linux

Bison version: bison (GNU Bison) 2.4.3

Error when compiling:

```/bin/sh ../ylwrap grammar.y y.tab.c grammar.c y.tab.h `echo grammar.c | sed -e s/cc$/hh/ -e s/cpp$/hpp/ -e s/cxx$/hxx/ -e s/c++$/h++/ -e s/c$/h/` y.output grammar.output -- bison -y -d 
./yara/libyara/grammar.y:229.9-10: $$ for the midrule at $8 of `rule' has no declared type```

Fixed wrong version number (3.2.0) on Windows.

Added access to ELF segments from the elf module and added some constants concerning these segments:

PT_NULL, PT_LOAD, PT_DYNAMIC, PT_INTERP, PT_NOTE, PT_SHLIB, PT_PHDR, PT_TLS, PT_GNU_EH_FRAME, PT_GNU_STACK

Usage from the elf module is very similar to sections:

rule Loadable_segment {
        condition:
                for any n in (1..elf.number_of_segments) : (elf.segments[n].type == elf.PT_LOAD)
}