### PR TITLE
PE module: avoid segfault after failed allocation.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -849,6 +849,9 @@ IMPORTED_FUNCTION* pe_parse_import_descriptor(
         IMPORTED_FUNCTION* imported_func = (IMPORTED_FUNCTION*)
             yr_calloc(1, sizeof(IMPORTED_FUNCTION));
 
+        if (!imported_func)
+          continue;
+
         imported_func->name = name;
         imported_func->next = NULL;
 
@@ -901,6 +904,9 @@ IMPORTED_FUNCTION* pe_parse_import_descriptor(
       {
         IMPORTED_FUNCTION* imported_func = (IMPORTED_FUNCTION*)
             yr_calloc(1, sizeof(IMPORTED_FUNCTION));
+
+        if (!imported_func)
+          continue;
 
         imported_func->name = name;
         imported_func->next = NULL;


### PR DESCRIPTION
I have been playing with afl-fuzz and have found two possible null pointer dereferences in the PE module so far. This raises the question how such situations should be dealt with in general: Is no result better or worse than an incorrect/incomplete result?