### PR TITLE
Implement -D (--print-module-info).

### DIFF
--- a/libyara/include/yara/scan.h
+++ b/libyara/include/yara/scan.h
@@ -19,8 +19,10 @@ limitations under the License.
 
 #include <yara/types.h>
 
+// Bitmasks for flags.
 #define SCAN_FLAGS_FAST_MODE         1
 #define SCAN_FLAGS_PROCESS_MEMORY    2
+#define SHOW_MODULE_INFO             4
 
 
 int yr_scan_verify_match(

--- a/libyara/include/yara/scan.h
+++ b/libyara/include/yara/scan.h
@@ -22,7 +22,7 @@ limitations under the License.
 // Bitmasks for flags.
 #define SCAN_FLAGS_FAST_MODE         1
 #define SCAN_FLAGS_PROCESS_MEMORY    2
-#define SHOW_MODULE_INFO             4
+#define SCAN_FLAGS_SHOW_MODULE_INFO  4
 
 
 int yr_scan_verify_match(

--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -470,9 +470,8 @@ YR_API int yr_rules_scan_mem_blocks(
 
 _exit:
 
-  #ifdef PRINT_MODULE_DATA
-  yr_modules_print_data(&context);
-  #endif
+  if (flags & SHOW_MODULE_INFO)
+    yr_modules_print_data(&context);
 
   yr_modules_unload_all(&context);
 

--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -470,7 +470,7 @@ YR_API int yr_rules_scan_mem_blocks(
 
 _exit:
 
-  if (flags & SHOW_MODULE_INFO)
+  if (flags & SCAN_FLAGS_SHOW_MODULE_INFO)
     yr_modules_print_data(&context);
 
   yr_modules_unload_all(&context);

--- a/yara.c
+++ b/yara.c
@@ -94,6 +94,7 @@ char* ext_vars[MAX_ARGS_EXT_VAR + 1];
 char* modules_data[MAX_ARGS_EXT_VAR + 1];
 
 int recursive_search = FALSE;
+int show_module_info = FALSE;
 int show_tags = FALSE;
 int show_specified_tags = FALSE;
 int show_specified_rules = FALSE;
@@ -125,6 +126,9 @@ args_option_t options[] =
 
   OPT_BOOLEAN('n', "negate", &negate,
       "print only not satisfied rules (negate)", NULL),
+
+  OPT_BOOLEAN('D', "print-module-info", &show_module_info,
+      "print module information"),
 
   OPT_BOOLEAN('g', "print-tags", &show_tags,
       "print tags"),
@@ -639,6 +643,12 @@ void* scanning_thread(void* param)
   THREAD_ARGS* args = (THREAD_ARGS*) param;
   char* file_path = file_queue_get();
 
+  int flags = 0;
+  if (fast_scan)
+    flags |= SCAN_FLAGS_FAST_MODE;
+  if (show_module_info)
+    flags |= SHOW_MODULE_INFO;
+
   while (file_path != NULL)
   {
     int elapsed_time = (int) difftime(time(NULL), args->start_time);
@@ -648,7 +658,7 @@ void* scanning_thread(void* param)
       result = yr_rules_scan_file(
           args->rules,
           file_path,
-          fast_scan ? SCAN_FLAGS_FAST_MODE : 0,
+          flags,
           callback,
           file_path,
           timeout - elapsed_time);
@@ -984,10 +994,16 @@ int main(
   {
     int pid = atoi(argv[1]);
 
+    int flags = 0;
+    if (fast_scan)
+      flags |= SCAN_FLAGS_FAST_MODE;
+    if (show_module_info)
+      flags |= SHOW_MODULE_INFO;
+
     result = yr_rules_scan_proc(
         rules,
         pid,
-        fast_scan ? SCAN_FLAGS_FAST_MODE : 0,
+        flags,
         callback,
         (void*) argv[1],
         timeout);
@@ -1040,10 +1056,16 @@ int main(
   }
   else
   {
+    int flags = 0;
+    if (fast_scan)
+      flags |= SCAN_FLAGS_FAST_MODE;
+    if (show_module_info)
+      flags |= SHOW_MODULE_INFO;
+
     result = yr_rules_scan_file(
         rules,
         argv[1],
-        fast_scan ? SCAN_FLAGS_FAST_MODE : 0,
+        flags,
         callback,
         (void*) argv[1],
         timeout);

--- a/yara.c
+++ b/yara.c
@@ -647,7 +647,7 @@ void* scanning_thread(void* param)
   if (fast_scan)
     flags |= SCAN_FLAGS_FAST_MODE;
   if (show_module_info)
-    flags |= SHOW_MODULE_INFO;
+    flags |= SCAN_FLAGS_SHOW_MODULE_INFO;
 
   while (file_path != NULL)
   {
@@ -998,7 +998,7 @@ int main(
     if (fast_scan)
       flags |= SCAN_FLAGS_FAST_MODE;
     if (show_module_info)
-      flags |= SHOW_MODULE_INFO;
+      flags |= SCAN_FLAGS_SHOW_MODULE_INFO;
 
     result = yr_rules_scan_proc(
         rules,
@@ -1060,7 +1060,7 @@ int main(
     if (fast_scan)
       flags |= SCAN_FLAGS_FAST_MODE;
     if (show_module_info)
-      flags |= SHOW_MODULE_INFO;
+      flags |= SCAN_FLAGS_SHOW_MODULE_INFO;
 
     result = yr_rules_scan_file(
         rules,


### PR DESCRIPTION
Define another flag (SHOW_MODULE_INFO) which, when set, will dump the
module information via yr_modules_print_data.