### PR TITLE
Ensure thread ids are globally unique even if multiple rules instances.

### DIFF
--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -546,12 +546,6 @@ YR_API int yr_compiler_get_rules(
   yara_rules->code_start = rules_file_header->code_start;
   yara_rules->tidx_mask = 0;
 
-  #if _WIN32
-  yara_rules->mutex = CreateMutex(NULL, FALSE, NULL);
-  #else
-  pthread_mutex_init(&yara_rules->mutex, NULL);
-  #endif
-
   *rules = yara_rules;
 
   return ERROR_SUCCESS;

--- a/libyara/include/yara/rules.h
+++ b/libyara/include/yara/rules.h
@@ -53,7 +53,9 @@ limitations under the License.
 #define yr_rules_foreach(rules, rule) \
     for (rule = rules->rules_list_head; !RULE_IS_NULL(rule); rule++)
 
+YR_API int yr_rules_initialize();
 
+YR_API int yr_rules_finalize();
 
 YR_API int yr_rules_scan_mem(
     YR_RULES* rules,

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -347,8 +347,6 @@ typedef struct _YR_RULES {
   tidx_mask_t tidx_mask;
   uint8_t* code_start;
 
-  mutex_t mutex;
-
   YR_ARENA* arena;
   YR_RULE* rules_list_head;
   YR_EXTERNAL_VARIABLE* externals_list_head;

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -22,6 +22,7 @@ limitations under the License.
 #include <yara/re.h>
 #include <yara/modules.h>
 #include <yara/mem.h>
+#include <yara/rules.h>
 
 #ifdef _WIN32
 #define snprintf _snprintf
@@ -75,6 +76,7 @@ YR_API int yr_initialize(void)
   pthread_key_create(&recovery_state_key, NULL);
   #endif
 
+  FAIL_ON_ERROR(yr_rules_initialize());
   FAIL_ON_ERROR(yr_re_initialize());
   FAIL_ON_ERROR(yr_modules_initialize());
 
@@ -116,6 +118,7 @@ YR_API int yr_finalize(void)
 
   FAIL_ON_ERROR(yr_re_finalize());
   FAIL_ON_ERROR(yr_modules_finalize());
+  FAIL_ON_ERROR(yr_rules_finalize());
   FAIL_ON_ERROR(yr_heap_free());
 
   return ERROR_SUCCESS;


### PR DESCRIPTION
Fixes multi-threaded issue where if you instantiate multiple instances of YARA_RULE objects you will get thread id collisions causing race conditions and occasional segfaults with module unload.