### PR TITLE
PE module: Fix bounds check for iterating over certificates

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1084,6 +1084,7 @@ void pe_parse_certificates(
   PWIN_CERTIFICATE win_cert = (PWIN_CERTIFICATE) \
       (pe->data + directory->VirtualAddress);
 
+  fprintf(stderr, "wim_cert = %p eod = %p\n", win_cert, eod);
   //
   // Walk the directory, pulling out certificates.
   //
@@ -1096,7 +1097,8 @@ void pe_parse_certificates(
   // included).
   //
 
-  while ((uint8_t*) win_cert + sizeof(WIN_CERTIFICATE) <= eod &&
+  while (struct_fits_in_pe(pe, (uint8_t*) win_cert, WIN_CERTIFICATE) &&
+         (uint8_t*) win_cert + sizeof(WIN_CERTIFICATE) <= eod &&
          (uint8_t*) win_cert->Certificate + win_cert->Length - 8 <= eod)
   {
     // Some sanity checks


### PR DESCRIPTION
Found using afl-fuzz