### PR TITLE
PE module: Do not use strlcpy()-type functions

### DIFF
--- a/libyara/include/yara/strutils.h
+++ b/libyara/include/yara/strutils.h
@@ -68,7 +68,7 @@ int strcmp_w(
     const char* str);
 
 
-size_t strlcpy_w(
+char* strncpy_w(
     char* dst,
     const char* w_src,
     size_t n);

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -709,8 +709,10 @@ void pe_parse_version_info(
             char key[64];
             char value[256];
 
-            strlcpy_w(key, string->Key, sizeof(key));
-            strlcpy_w(value, string_value, sizeof(value));
+            strncpy_w(key, string->Key, sizeof(key));
+            key[sizeof(key)-1] = 0;
+            strncpy_w(value, string_value, sizeof(value));
+            value[sizeof(value)-1] = 0;
 
             set_string(value, pe->object, "version_info[%s]", key);
           }
@@ -1304,7 +1306,8 @@ void pe_parse_header(
     if (!struct_fits_in_pe(pe, section, IMAGE_SECTION_HEADER))
       break;
 
-    strlcpy(section_name, (char*) section->Name, IMAGE_SIZEOF_SHORT_NAME + 1);
+    strncpy(section_name, (char*) section->Name, IMAGE_SIZEOF_SHORT_NAME + 1);
+    section_name[IMAGE_SIZEOF_SHORT_NAME] = 0;
 
     set_string(
         section_name,

--- a/libyara/strutils.c
+++ b/libyara/strutils.c
@@ -186,28 +186,23 @@ int strcmp_w(
   return w_str[0] - *str;
 }
 
-
-size_t strlcpy_w(
-    char* dst,
+/*
+strncpy()-type function that does a quick&dirty UTF-16-LE-to-Latin1
+conversion
+*/
+char* strncpy_w(
+    char* dest,
     const char* w_src,
     size_t n)
 {
-  register char* d = dst;
-  register const char* s = w_src;
+  size_t i;
 
-  while (n > 1 && *s != 0)
-  {
-    *d = *s;
-    d += 1;
-    n -= 1;
-    s += 2;
-  }
+  for (i = 0; i < n && (w_src[2*i] != '\0' || w_src[2*i+1] != '\0'); i++)
+    dest[i] = w_src[2*i];
+  for ( ; i < n; i++)
+    dest[i] = '\0';
 
-  while (*s) s += 2;
-
-  *d = '\0';
-
-  return (s - w_src) / 2;
+  return dest;
 }
 
 


### PR DESCRIPTION
strlcpy() reads from the source buffer until it hits a null character
to determine the string length. This may lead to crashes due to
out-of-bounds reads.

Since we don't use the string length, using strncpy() and making sure
that the target buffer is null-terminated is safer.