### PR TITLE
Fix Error_on_warning in yara-python

### DIFF
--- a/yara-python/yara-python.c
+++ b/yara-python/yara-python.c
@@ -1481,8 +1481,6 @@ static PyObject* yara_compile(
     if (error != ERROR_SUCCESS)
       return handle_error(error, NULL);
 
-    yr_compiler_set_callback(compiler, raise_exception_on_error, NULL);
-
     if (error_on_warning != NULL)
     {
       if (PyBool_Check(error_on_warning))


### PR DESCRIPTION
Without this patch it was impossible to supress error on warning in python because it was set before the check, and nothing was done to unset it.