### PR TITLE
Posix compliant +1 to include null terminator

### DIFF
--- a/yara.c
+++ b/yara.c
@@ -45,7 +45,7 @@ limitations under the License.
 #define ERROR_COULD_NOT_CREATE_THREAD  100
 
 #ifndef MAX_PATH
-#define MAX_PATH 255
+#define MAX_PATH 256
 #endif
 
 #ifndef min

--- a/yarac.c
+++ b/yarac.c
@@ -37,7 +37,7 @@ limitations under the License.
 #include "config.h"
 
 #ifndef MAX_PATH
-#define MAX_PATH 255
+#define MAX_PATH 256
 #endif
 
 #define MAX_ARGS_EXT_VAR   32


### PR DESCRIPTION
If using this `PATH_MAX` definition, to keep [posix](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html) compliant, add one to the current size or the path will get cutoff one `char` short when accounting for the null-terminator.