### PR TITLE
Exporting the library version to Python.

### DIFF
--- a/yara-python/yara-python.c
+++ b/yara-python/yara-python.c
@@ -1858,6 +1858,7 @@ MOD_INIT(yara)
 
   PyModule_AddIntConstant(m, "CALLBACK_CONTINUE", 0);
   PyModule_AddIntConstant(m, "CALLBACK_ABORT", 1);
+  PyModule_AddStringConstant(m, "__version__", YR_VERSION);
   PyModule_AddStringConstant(m, "YARA_VERSION", YR_VERSION);
   PyModule_AddIntConstant(m, "YARA_VERSION_HEX", YR_VERSION_HEX);
 

--- a/yara-python/yara-python.c
+++ b/yara-python/yara-python.c
@@ -1858,6 +1858,8 @@ MOD_INIT(yara)
 
   PyModule_AddIntConstant(m, "CALLBACK_CONTINUE", 0);
   PyModule_AddIntConstant(m, "CALLBACK_ABORT", 1);
+  PyModule_AddStringConstant(m, "YARA_VERSION", YR_VERSION);
+  PyModule_AddIntConstant(m, "YARA_VERSION_HEX", YR_VERSION_HEX);
 
 #if PYTHON_API_VERSION >= 1007
   YaraError = PyErr_NewException("yara.Error", PyExc_Exception, NULL);


### PR DESCRIPTION
I'd really like to see the yara version from Python code, not sure if this is possible already? If not, this PR would export it in future versions.