### PR TITLE
escape metadata values

### DIFF
--- a/yara.c
+++ b/yara.c
@@ -400,6 +400,39 @@ void print_string(
   printf("\n");
 }
 
+void print_escaped(
+        char* str,
+        int length)
+{
+  for (int i = 0; i < length; i++) {
+    switch (str[i]) {
+      case '\"':
+            printf("\\\"");
+            break;
+      case '\'':
+            printf("\\\'");
+            break;
+      case '\\':
+            printf("\\\\");
+            break;
+      case '\a':
+            printf("\\a");
+            break;
+      case '\b':
+            printf("\\b");
+            break;
+      case '\n':
+            printf("\\n");
+            break;
+      case '\t':
+            printf("\\t");
+            break;
+            // and so on
+      default:
+        printf("%c", str[i]);
+    }
+  }
+}
 
 void print_hex_string(
     uint8_t* data,
@@ -413,7 +446,6 @@ void print_hex_string(
 
   printf("\n");
 }
-
 
 void print_scanner_error(int error)
 {
@@ -553,8 +585,11 @@ int handle_message(int message, YR_RULE* rule, void* data)
           printf("%s=%" PRId64, meta->identifier, meta->integer);
         else if (meta->type == META_TYPE_BOOLEAN)
           printf("%s=%s", meta->identifier, meta->integer ? "true" : "false");
-        else
-          printf("%s=\"%s\"", meta->identifier, meta->string);
+        else {
+          printf("%s=\"", meta->identifier);
+          print_escaped(meta->string, strlen(meta->string));
+          printf("\"");
+        }
       }
 
       printf("] ");


### PR DESCRIPTION
escape matched rules metadata values when printing, for example when the following rule matches 

rule EscapeMeta {
  meta:
      name = "this is a \"test\""
  strings:
      $a = "test"
   condition:
      $a
}

the new output will be

     EscapeMeta [name="this is a \"test\""] test.yara

instead of

     EscapeMeta [name="this is a "test""] test.yara