### PR TITLE
Fix hash module.

### DIFF
--- a/libyara/modules.c
+++ b/libyara/modules.c
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <config.h>
+
 #include <yara/exec.h>
 #include <yara/modules.h>
 #include <yara/libyara.h>


### PR DESCRIPTION
This fixes a regression introduced in 9397c30, which causes the hash
module to not be found by yara. For example, after 9397c30 was commited
this happens after building yara:

wxs@psh yara % nm ./yara | grep string_md5
wxs@psh yara %

The "string_md5" symbol is one that is from hash.c. Looking at the build
log hash.c is compiled and the "string_md5" symbol is in
libyara/.libs/libyara.a and libyara/.libs/libyara.dylib after
compilation. But when yara is linked, the entire hash module is left
out.

After a bisection 9397c30 was found to be the culprit and the only
answer was this particular line being removed.