### PR TITLE
Crypto crash fix

### DIFF
--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -143,15 +143,15 @@ YR_API int yr_finalize(void)
 {
   yr_re_finalize_thread();
 
+  if (--init_count > 0)
+    return ERROR_SUCCESS;
+
   #ifdef HAVE_LIBCRYPTO
   int i;
   for (i = 0; i < CRYPTO_num_locks(); i ++)
     pthread_mutex_destroy(&locks[i]);
   OPENSSL_free(locks);
   #endif
-
-  if (--init_count > 0)
-    return ERROR_SUCCESS;
 
   #ifdef _WIN32
   TlsFree(tidx_key);

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -140,13 +140,16 @@ YR_API void yr_finalize_thread(void)
 
 YR_API int yr_finalize(void)
 {
+  #ifdef HAVE_LIBCRYPTO
+  int i;
+  #endif
+
   yr_re_finalize_thread();
 
   if (--init_count > 0)
     return ERROR_SUCCESS;
 
   #ifdef HAVE_LIBCRYPTO
-  int i;
   for (i = 0; i < CRYPTO_num_locks(); i ++)
     pthread_mutex_destroy(&locks[i]);
   OPENSSL_free(locks);

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -107,7 +107,6 @@ YR_API int yr_initialize(void)
   for (i = 0; i < CRYPTO_num_locks(); i++)
     pthread_mutex_init(&locks[i], NULL);
 
-  // XXX ifdef CRYPTO
   CRYPTO_set_id_callback((unsigned long (*)())pthreads_thread_id);
   CRYPTO_set_locking_callback(locking_function);
   #endif


### PR DESCRIPTION
Fix a crash in OpenSSL due to not properly initializing with respect to threading.