### PR TITLE
Bump MAX_PE_IMPORTS to 16384.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -73,7 +73,7 @@ limitations under the License.
 
 
 #define MAX_PE_SECTIONS              96
-#define MAX_PE_IMPORTS               256
+#define MAX_PE_IMPORTS               16384
 #define MAX_PE_EXPORTS               65535
 
 


### PR DESCRIPTION
Because the imports are parsed and stored for later analysis anytime we
run into the limit, imphash(), imports() and related functions would
return incorrect results when compared to other tools.

This is a compromise to bump it up from 256 to 16384 but it ultimately
doesn't fix the problem that was introduced in 1cc98f7. It seems to be a
conflict of interest between parsing accuracy and memory usage.