### PR TITLE
Fix build on OS X.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,10 @@ case $host_alias in
      i?86-*-mingw*) CFLAGS="$CFLAGS -D__MINGW_USE_VC2005_COMPAT" ;;
 esac
 
+case $host_os in
+    darwin*) CFLAGS="$CFLAGS -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib" ;;
+esac
+
 
 AC_ARG_ENABLE([profiling],
   [AS_HELP_STRING([--enable-profiling], [enable profiling support])],


### PR DESCRIPTION
With the latest Xcode on OS X, Apple removed the OpenSSL headers but
left the libraries. This meant the configure script was finding
libcrypto in /usr/lib but building things including OpenSSL headers
would fail.

Since building anything that uses OpenSSL is now broken, the only
reasonable way forward is to use OpenSSL from brew (or something else).
This commit fixes the build to look in the standard brew location for
OpenSSL for OS X.

For more information see this link:
http://lists.apple.com/archives/macnetworkprog/2015/Jun/msg00025.html

Fixes #351.