### PR TITLE
Fix certificate parsing.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1134,7 +1134,7 @@ void pe_parse_certificates(
   //
 
   while (struct_fits_in_pe(pe, win_cert, WIN_CERTIFICATE) &&
-         fits_in_pe(pe, win_cert->Certificate, win_cert->Length) &&
+         fits_in_pe(pe, win_cert->Certificate, (win_cert->Length - (sizeof(DWORD) + (sizeof(WORD) * 2)))) &&
          win_cert->Length >= 8 &&
          (uint8_t*) win_cert + sizeof(WIN_CERTIFICATE) <= eod &&
          (uint8_t*) win_cert->Certificate < eod &&


### PR DESCRIPTION
Looks like 5d6d8b1e9f3b4fc2b51857366048a7e9f8bd3708 is breaking parsing
of certificates. win_cert->Length is the length of the entire win_cert
structure. By using win_cert->Certificate as the pointer and
win_cert->Length as the size, the check will always fail because the
length needs to be decremented by the number of bytes you skipped over
when starting from win_cert->Certificate.

Fix this by decrementing length for the number of bytes we just skipped
over.