### PR TITLE
Fix bad returns.

### DIFF
--- a/libyara/modules/math.c
+++ b/libyara/modules/math.c
@@ -82,7 +82,7 @@ define_function(data_entropy)
   YR_MEMORY_BLOCK* block = NULL;
   
   if (offset < 0 || length < 0 || offset < context->mem_block->base)
-    return ERROR_WRONG_ARGUMENTS;
+    return_float(UNDEFINED);
 
   data = (uint32_t*) yr_calloc(256, sizeof(uint32_t));
 
@@ -179,7 +179,7 @@ define_function(data_deviation)
   YR_MEMORY_BLOCK* block = NULL;
 
   if (offset < 0 || length < 0 || offset < context->mem_block->base)
-    return ERROR_WRONG_ARGUMENTS;
+    return_float(UNDEFINED);
  
   foreach_memory_block(context, block)
   {
@@ -249,7 +249,7 @@ define_function(data_mean)
   size_t i;
 
   if (offset < 0 || length < 0 || offset < context->mem_block->base)
-    return ERROR_WRONG_ARGUMENTS;
+    return_float(UNDEFINED);
  
   foreach_memory_block(context, block)
   {
@@ -311,7 +311,7 @@ define_function(data_serial_correlation)
   double scc = 0;
 
   if (offset < 0 || length < 0 || offset < context->mem_block->base)
-    return ERROR_WRONG_ARGUMENTS;
+    return_float(UNDEFINED);
  
   foreach_memory_block(context, block)
   {
@@ -422,7 +422,7 @@ define_function(data_monte_carlo_pi)
   YR_MEMORY_BLOCK* block = NULL;
 
   if (offset < 0 || length < 0 || offset < context->mem_block->base)
-    return ERROR_WRONG_ARGUMENTS;
+    return_float(UNDEFINED);
  
   foreach_memory_block(context, block)
   {


### PR DESCRIPTION
Fix cases where returning ERROR_WRONG_ARGUMENTS is the incorrect thing to do,
because it causes execution of all rules to halt. The proper thing to do in
these particular cases is to return UNDEFINED because we can't possibly do the
requested operation given the argument values.

Fixes #381.