### PR TITLE
Exposing IMAGE_RESOURCE_DIRECTORY fields and removing Characteristics…

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -151,6 +151,7 @@ typedef struct _PE
   YR_OBJECT* object;
   IMPORTED_DLL* imported_dlls;
   uint32_t resources;
+  uint32_t resources_dir;
 
 } PE;
 
@@ -472,10 +473,46 @@ int _pe_iterate_resources(
 {
   int result = RESOURCE_ITERATOR_FINISHED;
 
-  // A few sanity checks to avoid corrupt files
+  // The directory entry should be populated even if the sanity checks aren't
+  // satisfied to allow for signatures on malformed files.
 
-  if (resource_dir->Characteristics != 0 ||
-      resource_dir->NumberOfNamedEntries > 32768 ||
+  set_integer(
+      resource_dir->Characteristics,
+      pe->object,
+      "resources_dir[%i].characteristics",
+      pe->resources_dir);
+  set_integer(
+      resource_dir->TimeDateStamp,
+      pe->object,
+      "resources_dir[%i].time_date_stamp",
+      pe->resources_dir);
+  set_integer(
+      resource_dir->MajorVersion,
+      pe->object,
+      "resources_dir[%i].major_version",
+      pe->resources_dir);
+  set_integer(
+      resource_dir->MinorVersion,
+      pe->object,
+      "resources_dir[%i].minor_version",
+      pe->resources_dir);
+  set_integer(
+      resource_dir->NumberOfNamedEntries,
+      pe->object,
+      "resources_dir[%i].number_of_named_entries",
+      pe->resources_dir);
+  set_integer(
+      resource_dir->NumberOfIdEntries,
+      pe->object,
+      "resources_dir[%i].number_of_id_entries",
+      pe->resources_dir);
+  pe->resources_dir += 1;
+
+  // A few sanity checks to avoid corrupt files. Characteristics of 0 shouldn't
+  // be used for sanity check as valid resource entries can have arbitrary
+  // values of this field.
+
+  if (resource_dir->NumberOfNamedEntries > 32768 ||
       resource_dir->NumberOfIdEntries > 32768)
   {
     return result;
@@ -1296,6 +1333,7 @@ void pe_parse_header(
       (void*) pe);
 
   set_integer(pe->resources, pe->object, "number_of_resources");
+  set_integer(pe->resources_dir, pe->object, "number_of_resources_dir");
 
   section = IMAGE_FIRST_SECTION(pe->header);
 
@@ -1836,6 +1874,15 @@ begin_declarations;
     declare_string("language_string");
   end_struct_array("resources");
   declare_integer("number_of_resources");
+  begin_struct_array("resources_dir");
+    declare_integer("characteristics");
+    declare_integer("time_date_stamp");
+    declare_integer("major_version");
+    declare_integer("minor_version");
+    declare_integer("number_of_named_entries");
+    declare_integer("number_of_id_entries");
+  end_struct_array("resources_dir");
+  declare_integer("number_of_resources_dir");
 
   #if defined(HAVE_LIBCRYPTO)
   begin_struct_array("signatures");
@@ -2136,6 +2183,7 @@ int module_load(
         pe->header = pe_header;
         pe->object = module_object;
         pe->resources = 0;
+        pe->resources_dir = 0;
 
         module_object->data = pe;
 


### PR DESCRIPTION
IMAGE_RESOURCE_DIRECTORY fields are currently treated as variables which doesn't account for multiple directories having different field values. Creating struct array for resources_dir to reflect this which enables for the following signatures:
`for any i in (0 .. pe.number_of_resources_dir - 1) : ( pe.resources_dir[i].characteristics == 0xbadc00de )`

Also removing `resource_dir->Characteristics` sanity check as the Characteristics field can have arbitrary value. 

Fixes #295.