### PR TITLE
Fix rule alignments

### DIFF
--- a/libyara/Makefile.am
+++ b/libyara/Makefile.am
@@ -110,6 +110,10 @@ libyara_la_SOURCES = \
 pkgconfigdir = $(libdir)/pkgconfig
 nodist_pkgconfig_DATA = yara.pc
 
+TESTS = $(check_PROGRAMS)
+check_PROGRAMS = test-alignment
+test_alignment_SOURCES = test-alignment.c
+
 yara.pc: yara.pc.in
 		sed -e 's![@]prefix[@]!$(prefix)!g' \
 		    -e 's![@]exec_prefix[@]!$(exec_prefix)!g' \

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <yara/re.h>
 #include <yara/limits.h>
 #include <yara/hash.h>
+#include <yara/utils.h>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -39,7 +40,7 @@ typedef int32_t tidx_mask_t;
 
 
 #define DECLARE_REFERENCE(type, name) \
-    union { type name; int64_t name##_; }
+    union { type name; int64_t name##_; } YR_ALIGN(8)
 
 #pragma pack(push)
 #pragma pack(8)
@@ -68,7 +69,7 @@ typedef struct _YR_NAMESPACE
 typedef struct _YR_META
 {
   int32_t type;
-  int64_t integer;
+  YR_ALIGN(8) int64_t integer;
 
   DECLARE_REFERENCE(const char*, identifier);
   DECLARE_REFERENCE(char*, string);
@@ -85,10 +86,10 @@ typedef struct _YR_MATCH
   union {
     uint8_t* data;           // Confirmed matches use "data",
     int32_t chain_length;    // unconfirmed ones use "chain_length"
-  };
+  } YR_ALIGN(8);
 
-  struct _YR_MATCH*  prev;
-  struct _YR_MATCH*  next;
+  YR_ALIGN(8) struct _YR_MATCH* prev;
+  YR_ALIGN(8) struct _YR_MATCH* next;
 
 } YR_MATCH;
 
@@ -259,7 +260,7 @@ typedef struct _YR_EXTERNAL_VARIABLE
 {
   int32_t type;
 
-  union {
+  YR_ALIGN(8) union {
     int64_t i;
     double f;
     char* s;

--- a/libyara/include/yara/utils.h
+++ b/libyara/include/yara/utils.h
@@ -44,6 +44,14 @@ limitations under the License.
 #define YR_API EXTERNC
 #endif
 
+#if defined(__GNUC__)
+#define YR_ALIGN(n) __attribute__((aligned(n)))
+#elif defined(_MSC_VER)
+#define YR_ALIGN(n) __declspec(align(n))
+#else
+#define YR_ALIGN(n)
+#endif
+
 #define yr_min(x, y) ((x < y) ? (x) : (y))
 #define yr_max(x, y) ((x > y) ? (x) : (y))
 

--- a/libyara/test-alignment.c
+++ b/libyara/test-alignment.c
@@ -1,0 +1,137 @@
+/*
+Copyright (c) 2016. The YARA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <yara.h>
+#include <stdio.h>
+
+int err = 0;
+
+#define CHECK_SIZE(expr,size)                          \
+  do                                                   \
+  {                                                    \
+    printf("sizeof("#expr") = %lu ...", sizeof(expr)); \
+    if (sizeof(expr) == size)                          \
+    {                                                  \
+      puts("ok");                                      \
+    }                                                  \
+    else                                               \
+    {                                                  \
+      printf("expected %d\n", size);                   \
+      err = 1;                                         \
+    }                                                  \
+  } while (0);
+
+#define CHECK_OFFSET(expr,offset,subexpr)             \
+  do                                                  \
+  {                                                   \
+    printf("offsetof("#expr", "#subexpr") = %lu ...", \
+           offsetof(expr, subexpr));                  \
+    if (offsetof(expr, subexpr) == offset)            \
+    {                                                 \
+      puts("ok");                                     \
+    }                                                 \
+    else                                              \
+    {                                                 \
+      printf("expected %d\n", offset);                \
+    }                                                 \
+  } while (0)
+
+int main (int argc, char **argv) {
+  CHECK_SIZE(YR_NAMESPACE, 4*MAX_THREADS + 8);
+  CHECK_OFFSET(YR_NAMESPACE, 4*MAX_THREADS, name);
+
+  CHECK_SIZE(YR_META, 32);
+  CHECK_OFFSET(YR_META, 8,  integer);
+  CHECK_OFFSET(YR_META, 16, identifier);
+  CHECK_OFFSET(YR_META, 24, string);
+
+  CHECK_SIZE(YR_MATCH, 48);
+  CHECK_OFFSET(YR_MATCH, 8,  offset);
+  CHECK_OFFSET(YR_MATCH, 16, length);
+  CHECK_OFFSET(YR_MATCH, 24, data);
+  CHECK_OFFSET(YR_MATCH, 24, chain_length);
+  CHECK_OFFSET(YR_MATCH, 32, prev);
+  CHECK_OFFSET(YR_MATCH, 40, next);
+  
+  CHECK_SIZE(YR_MATCHES, 24);
+  CHECK_OFFSET(YR_MATCHES, 8,  head);
+  CHECK_OFFSET(YR_MATCHES, 16, tail);
+
+  CHECK_SIZE(YR_STRING, 48 + 2 * 24 /* YR_MATCHES */ * MAX_THREADS
+#            ifdef PROFILING_ENABLED             
+             + 8
+#            endif
+             );
+  CHECK_OFFSET(YR_STRING, 4,  length);
+  CHECK_OFFSET(YR_STRING, 8,  identifier);
+  CHECK_OFFSET(YR_STRING, 16, string);
+  CHECK_OFFSET(YR_STRING, 24, chained_to);
+  CHECK_OFFSET(YR_STRING, 32, chain_gap_min);
+  CHECK_OFFSET(YR_STRING, 36, chain_gap_max);
+  CHECK_OFFSET(YR_STRING, 40, fixed_offset);
+
+  CHECK_SIZE(YR_RULE, 8 + 4*MAX_THREADS + 40
+#            ifdef PROFILING_ENABLED             
+             + 8
+#            endif
+             );
+  CHECK_OFFSET(YR_RULE, 4,                      t_flags);
+  CHECK_OFFSET(YR_RULE, 8 + 4*MAX_THREADS,      identifier);
+  CHECK_OFFSET(YR_RULE, 8 + 4*MAX_THREADS + 8,  tags);
+  CHECK_OFFSET(YR_RULE, 8 + 4*MAX_THREADS + 16, metas);
+  CHECK_OFFSET(YR_RULE, 8 + 4*MAX_THREADS + 24, strings);
+  CHECK_OFFSET(YR_RULE, 8 + 4*MAX_THREADS + 32, ns);
+
+  CHECK_SIZE(YR_EXTERNAL_VARIABLE, 24);
+  CHECK_OFFSET(YR_EXTERNAL_VARIABLE, 8,  value.i);
+  CHECK_OFFSET(YR_EXTERNAL_VARIABLE, 8,  value.f);
+  CHECK_OFFSET(YR_EXTERNAL_VARIABLE, 8,  value.s);
+  CHECK_OFFSET(YR_EXTERNAL_VARIABLE, 16, identifier);
+  
+  CHECK_SIZE(YR_AC_MATCH, 40);
+  CHECK_OFFSET(YR_AC_MATCH, 8,  string);
+  CHECK_OFFSET(YR_AC_MATCH, 16, forward_code);
+  CHECK_OFFSET(YR_AC_MATCH, 24, backward_code);
+  CHECK_OFFSET(YR_AC_MATCH, 32, next);
+
+  CHECK_SIZE(YR_AC_STATE,24);
+  CHECK_OFFSET(YR_AC_STATE, 8,  failure);
+  CHECK_OFFSET(YR_AC_STATE, 16, matches);
+
+  CHECK_SIZE(YR_AC_STATE_TRANSITION, 24);
+  CHECK_OFFSET(YR_AC_STATE_TRANSITION, 8,  state);
+  CHECK_OFFSET(YR_AC_STATE_TRANSITION, 16, next);
+
+  CHECK_SIZE(YR_AC_TABLE_BASED_STATE, 2072);
+  CHECK_OFFSET(YR_AC_TABLE_BASED_STATE, 8,  failure);
+  CHECK_OFFSET(YR_AC_TABLE_BASED_STATE, 16, matches);
+  CHECK_OFFSET(YR_AC_TABLE_BASED_STATE, 24, transitions);
+
+  CHECK_SIZE(YR_AC_LIST_BASED_STATE,32);
+  CHECK_OFFSET(YR_AC_LIST_BASED_STATE, 8,  failure);
+  CHECK_OFFSET(YR_AC_LIST_BASED_STATE, 16, matches);
+  CHECK_OFFSET(YR_AC_LIST_BASED_STATE, 24, transitions);
+
+  CHECK_SIZE(YR_AC_AUTOMATON, 8);
+
+  CHECK_SIZE(YARA_RULES_FILE_HEADER, 40);
+  CHECK_OFFSET(YARA_RULES_FILE_HEADER, 8,  rules_list_head);
+  CHECK_OFFSET(YARA_RULES_FILE_HEADER, 16, externals_list_head);
+  CHECK_OFFSET(YARA_RULES_FILE_HEADER, 24, code_start);
+  CHECK_OFFSET(YARA_RULES_FILE_HEADER, 32, automaton);
+
+  return err;
+}


### PR DESCRIPTION
This is my proposal for fixing #389 by making struct member alignments explicit where necessary.