### PR TITLE
Fix match issue.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1529,6 +1529,8 @@ define_function(exports)
 
   int64_t offset;
   uint32_t i;
+  size_t remaining;
+  size_t searchlen;
 
   // If not a PE file, return UNDEFINED
 
@@ -1563,6 +1565,7 @@ define_function(exports)
       exports->NumberOfNames * sizeof(DWORD) > pe->data_size - offset)
     return_integer(0);
 
+  searchlen = strlen(function_name);
   names = (DWORD*)(pe->data + offset);
 
   for (i = 0; i < exports->NumberOfNames; i++)
@@ -1572,6 +1575,10 @@ define_function(exports)
 
     if (offset < 0)
       return_integer(0);
+
+    remaining = pe->data_size - (size_t) offset;
+    if (remaining < searchlen)
+      continue;
 
     name = (char*)(pe->data + offset);
 


### PR DESCRIPTION
When the length of remaining bytes is less than the length of the string we are
searching for, don't do the search as it can't possibly match. This was causing
false positives when using a rule that looks like this:

pe.exports("Driver")

Anything that starts with "D" will be incorrectly matched when run against
b71c531d50d2b634e6000fcdabc9bbb4, because the file is truncated in the export
table and the entry happens to start with D.