### PR TITLE
Fixing compilation warnings in Visual Studio 2013.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1838,7 +1838,7 @@ define_function(locale)
 define_function(language)
 {
   YR_OBJECT* module = module();
-  PE* pe = module->data;
+  PE* pe = (PE*) module->data;
 
   uint64_t language = integer_argument(1);
   int64_t n, i;
@@ -1881,7 +1881,7 @@ define_function(is_dll)
 define_function(is_32bit)
 {
   YR_OBJECT* module = module();
-  PE* pe = module->data;
+  PE* pe = (PE*) module->data;
 
   if (pe == NULL)
     return_integer(UNDEFINED);
@@ -1893,7 +1893,7 @@ define_function(is_32bit)
 define_function(is_64bit)
 {
   YR_OBJECT* module = module();
-  PE* pe = module->data;
+  PE* pe = (PE*) module->data;
 
   if (pe == NULL)
     return_integer(UNDEFINED);

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -468,7 +468,7 @@ YR_STRING* yr_parser_reduce_string_declaration(
   // Determine if a string with the same identifier was already defined
   // by searching for the identifier in string_table.
 
-  string = yr_hash_table_lookup(
+  string = (YR_STRING*) yr_hash_table_lookup(
       compiler->strings_table,
       identifier,
       NULL);


### PR DESCRIPTION
Found some compilation warnings about requiring explicit casts for a few of the void* -> PE* and YR_STRING*. This fixes those warnings and gets libyara compiling under Visual Studio 2013 (with 2010 tools).