### PR TITLE
Add support for compiling under cygwin.

### DIFF
--- a/libyara/compiler.c
+++ b/libyara/compiler.c
@@ -556,7 +556,7 @@ YR_API int yr_compiler_get_rules(
   yara_rules->code_start = rules_file_header->code_start;
   yara_rules->tidx_mask = 0;
 
-  #if _WIN32
+  #if _WIN32 || __CYGWIN__
   yara_rules->mutex = CreateMutex(NULL, FALSE, NULL);
   #else
   pthread_mutex_init(&yara_rules->mutex, NULL);

--- a/libyara/exception.h
+++ b/libyara/exception.h
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include <assert.h>
 
-#if _WIN32
+#if _WIN32 || __CYGWIN__
 
 #include <windows.h>
 #include <setjmp.h>

--- a/libyara/filemap.c
+++ b/libyara/filemap.c
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include <fcntl.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 #else
 #include <sys/stat.h>
@@ -77,7 +77,7 @@ YR_API int yr_filemap_map(
 //       ERROR_COULD_NOT_MAP_FILE
 //
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 
 YR_API int yr_filemap_map_fd(
     YR_FILE_DESCRIPTOR file,
@@ -248,7 +248,7 @@ YR_API int yr_filemap_map_fd(
 //       ERROR_COULD_NOT_MAP_FILE
 //
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 
 YR_API int yr_filemap_map_ex(
     const char* file_path,

--- a/libyara/hex_lexer.c
+++ b/libyara/hex_lexer.c
@@ -34,7 +34,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -51,7 +51,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
@@ -182,7 +182,7 @@ typedef size_t yy_size_t;
 
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
      *       access to the local variable yy_act. Since yyless() is a macro, it would break
-     *       existing scanners that call yyless() from OUTSIDE hex_yylex. 
+     *       existing scanners that call yyless() from OUTSIDE hex_yylex.
      *       One obvious solution it to make yy_act a global. I tried that, and saw
      *       a 5% performance hit in a non-yylineno scanner, because yy_act is
      *       normally declared as a register variable-- so it is not worth it.
@@ -201,7 +201,7 @@ typedef size_t yy_size_t;
                     if ( *p == '\n' )\
                         --yylineno;\
             }while(0)
-    
+
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -258,7 +258,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -508,7 +508,7 @@ with noyywrap then we can remove this pragma.
 
 #include "hex_grammar.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #define snprintf _snprintf
 #endif
 
@@ -581,7 +581,7 @@ static int yy_init_globals (yyscan_t yyscanner );
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
     #    define yylval yyg->yylval_r
-    
+
 int hex_yylex_init (yyscan_t* scanner);
 
 int hex_yylex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
@@ -839,7 +839,7 @@ yy_find_action:
 			yy_size_t yyl;
 			for ( yyl = 0; yyl < yyleng; ++yyl )
 				if ( yytext[yyl] == '\n' )
-					   
+
     do{ yylineno++;
         yycolumn=0;
     }while(0)
@@ -1380,7 +1380,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	yyg->yy_hold_char = *++yyg->yy_c_buf_p;
 
 	if ( c == '\n' )
-		   
+
     do{ yylineno++;
         yycolumn=0;
     }while(0)
@@ -1463,7 +1463,7 @@ static void hex_yy_load_buffer_state  (yyscan_t yyscanner)
     YY_BUFFER_STATE hex_yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
-    
+
 	b = (YY_BUFFER_STATE) hex_yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in hex_yy_create_buffer()" );
@@ -1529,7 +1529,7 @@ static void hex_yy_load_buffer_state  (yyscan_t yyscanner)
     }
 
         b->yy_is_interactive = 0;
-    
+
 	errno = oerrno;
 }
 
@@ -1635,9 +1635,9 @@ static void hex_yyensure_buffer_stack (yyscan_t yyscanner)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
 			YY_FATAL_ERROR( "out of dynamic memory in hex_yyensure_buffer_stack()" );
-								  
+
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		yyg->yy_buffer_stack_max = num_to_alloc;
 		yyg->yy_buffer_stack_top = 0;
 		return;
@@ -1666,12 +1666,12 @@ static void hex_yyensure_buffer_stack (yyscan_t yyscanner)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * @param yyscanner The scanner object.
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE hex_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
-    
+
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
@@ -1707,7 +1707,7 @@ YY_BUFFER_STATE hex_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yys
  */
 YY_BUFFER_STATE hex_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
 {
-    
+
 	return hex_yy_scan_bytes(yystr,strlen(yystr) ,yyscanner);
 }
 
@@ -1724,7 +1724,7 @@ YY_BUFFER_STATE hex_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_
 	char *buf;
 	yy_size_t n;
 	yy_size_t i;
-    
+
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
 	buf = (char *) hex_yyalloc(n ,yyscanner );
@@ -1792,10 +1792,10 @@ YY_EXTRA_TYPE hex_yyget_extra  (yyscan_t yyscanner)
 int hex_yyget_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
-    
+
     return yylineno;
 }
 
@@ -1805,10 +1805,10 @@ int hex_yyget_lineno  (yyscan_t yyscanner)
 int hex_yyget_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
-    
+
     return yycolumn;
 }
 
@@ -1870,7 +1870,7 @@ void hex_yyset_lineno (int  line_number , yyscan_t yyscanner)
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
            YY_FATAL_ERROR( "hex_yyset_lineno called with no buffer" );
-    
+
     yylineno = line_number;
 }
 
@@ -1885,7 +1885,7 @@ void hex_yyset_column (int  column_no , yyscan_t yyscanner)
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
            YY_FATAL_ERROR( "hex_yyset_column called with no buffer" );
-    
+
     yycolumn = column_no;
 }
 
@@ -1980,20 +1980,20 @@ int hex_yylex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals 
         errno = EINVAL;
         return 1;
     }
-	
+
     *ptr_yy_globals = (yyscan_t) hex_yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
-	
+
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
-    
+
     /* By setting to 0xAA, we expose bugs in
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
-    
+
     hex_yyset_extra (yy_user_defined, *ptr_yy_globals);
-    
+
     return yy_init_globals ( *ptr_yy_globals );
 }
 
@@ -2113,7 +2113,7 @@ void hex_yyfree (void * ptr , yyscan_t yyscanner)
 
 
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 extern DWORD recovery_state_key;
 #else
@@ -2128,7 +2128,7 @@ void yyfatal(
 {
   jmp_buf* recovery_state;
 
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   recovery_state = (jmp_buf*) TlsGetValue(recovery_state_key) ;
   #else
   recovery_state = (jmp_buf*) pthread_getspecific(recovery_state_key);
@@ -2173,7 +2173,7 @@ int yr_parse_hex_string(
   lex_env.inside_or = 0;
   lex_env.token_count = 0;
 
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   TlsSetValue(recovery_state_key, (LPVOID) &recovery_state);
   #else
   pthread_setspecific(recovery_state_key, (void*) &recovery_state);
@@ -2212,4 +2212,3 @@ int yr_parse_hex_string(
 
   return ERROR_SUCCESS;
 }
-

--- a/libyara/include/yara/error.h
+++ b/libyara/include/yara/error.h
@@ -19,7 +19,7 @@ limitations under the License.
 
 #include <string.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 #endif
 

--- a/libyara/include/yara/filemap.h
+++ b/libyara/include/yara/filemap.h
@@ -23,7 +23,7 @@ limitations under the License.
 #include <sys/types.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 #define YR_FILE_DESCRIPTOR    HANDLE
 #else
@@ -41,7 +41,7 @@ typedef struct _YR_MAPPED_FILE
   YR_FILE_DESCRIPTOR  file;
   size_t              size;
   uint8_t*            data;
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   HANDLE              mapping;
   #endif
 

--- a/libyara/include/yara/limits.h
+++ b/libyara/include/yara/limits.h
@@ -17,7 +17,7 @@ limitations under the License.
 #ifndef YR_LIMITS_H
 #define YR_LIMITS_H
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 #endif
 

--- a/libyara/include/yara/pe.h
+++ b/libyara/include/yara/pe.h
@@ -16,7 +16,7 @@ limitations under the License.
 
 #pragma pack(push, 1)
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 
 // These definitions are not present in older Windows headers.

--- a/libyara/include/yara/strutils.h
+++ b/libyara/include/yara/strutils.h
@@ -23,7 +23,8 @@ limitations under the License.
 
 #include "config.h"
 
-#ifdef _WIN32
+// Cygwin already has these functions.
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #define snprintf _snprintf
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
@@ -74,4 +75,3 @@ size_t strlcpy_w(
     size_t n);
 
 #endif
-

--- a/libyara/include/yara/types.h
+++ b/libyara/include/yara/types.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include <yara/hash.h>
 #include <yara/utils.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 typedef HANDLE mutex_t;
 #else

--- a/libyara/lexer.c
+++ b/libyara/lexer.c
@@ -34,7 +34,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -51,7 +51,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
@@ -182,7 +182,7 @@ typedef size_t yy_size_t;
 
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
      *       access to the local variable yy_act. Since yyless() is a macro, it would break
-     *       existing scanners that call yyless() from OUTSIDE yara_yylex. 
+     *       existing scanners that call yyless() from OUTSIDE yara_yylex.
      *       One obvious solution it to make yy_act a global. I tried that, and saw
      *       a 5% performance hit in a non-yylineno scanner, because yy_act is
      *       normally declared as a register variable-- so it is not worth it.
@@ -201,7 +201,7 @@ typedef size_t yy_size_t;
                     if ( *p == '\n' )\
                         --yylineno;\
             }while(0)
-    
+
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -258,7 +258,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -620,9 +620,9 @@ static yyconst flex_int16_t yy_chk[455] =
 /* Table of booleans, true if rule could match eol. */
 static yyconst flex_int32_t yy_rule_can_match_eol[74] =
     {   0,
-0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 
-    0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+    0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0,     };
 
 /* The intent behind this definition is that it'll catch
@@ -713,9 +713,6 @@ with noyywrap then we can remove this pragma.
     str->flags = 0; \
   } \
 
-#ifdef _WIN32
-#define snprintf _snprintf
-#endif
 
 #define YY_NO_UNISTD_H 1
 #define YY_NO_INPUT 1
@@ -784,7 +781,7 @@ static int yy_init_globals (yyscan_t yyscanner );
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
     #    define yylval yyg->yylval_r
-    
+
 int yara_yylex_init (yyscan_t* scanner);
 
 int yara_yylex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
@@ -1041,7 +1038,7 @@ yy_find_action:
 			yy_size_t yyl;
 			for ( yyl = 0; yyl < yyleng; ++yyl )
 				if ( yytext[yyl] == '\n' )
-					   
+
     do{ yylineno++;
         yycolumn=0;
     }while(0)
@@ -1306,7 +1303,7 @@ YY_RULE_SETUP
     // make included file path relative to current source file
     s = strrchr(buffer, '/');
 
-    #ifdef _WIN32
+    #if defined(_WIN32) || defined(__CYGWIN__)
     b = strrchr(buffer, '\\'); // in Windows both path delimiters are accepted
     #endif
 
@@ -2210,7 +2207,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	yyg->yy_hold_char = *++yyg->yy_c_buf_p;
 
 	if ( c == '\n' )
-		   
+
     do{ yylineno++;
         yycolumn=0;
     }while(0)
@@ -2293,7 +2290,7 @@ static void yara_yy_load_buffer_state  (yyscan_t yyscanner)
     YY_BUFFER_STATE yara_yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
-    
+
 	b = (YY_BUFFER_STATE) yara_yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yara_yy_create_buffer()" );
@@ -2359,7 +2356,7 @@ static void yara_yy_load_buffer_state  (yyscan_t yyscanner)
     }
 
         b->yy_is_interactive = 0;
-    
+
 	errno = oerrno;
 }
 
@@ -2465,9 +2462,9 @@ static void yara_yyensure_buffer_stack (yyscan_t yyscanner)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
 			YY_FATAL_ERROR( "out of dynamic memory in yara_yyensure_buffer_stack()" );
-								  
+
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		yyg->yy_buffer_stack_max = num_to_alloc;
 		yyg->yy_buffer_stack_top = 0;
 		return;
@@ -2496,12 +2493,12 @@ static void yara_yyensure_buffer_stack (yyscan_t yyscanner)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * @param yyscanner The scanner object.
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yara_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
-    
+
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
@@ -2537,7 +2534,7 @@ YY_BUFFER_STATE yara_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yy
  */
 YY_BUFFER_STATE yara_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
 {
-    
+
 	return yara_yy_scan_bytes(yystr,strlen(yystr) ,yyscanner);
 }
 
@@ -2554,7 +2551,7 @@ YY_BUFFER_STATE yara_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes
 	char *buf;
 	yy_size_t n;
 	yy_size_t i;
-    
+
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
 	buf = (char *) yara_yyalloc(n ,yyscanner );
@@ -2622,10 +2619,10 @@ YY_EXTRA_TYPE yara_yyget_extra  (yyscan_t yyscanner)
 int yara_yyget_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
-    
+
     return yylineno;
 }
 
@@ -2635,10 +2632,10 @@ int yara_yyget_lineno  (yyscan_t yyscanner)
 int yara_yyget_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
-    
+
     return yycolumn;
 }
 
@@ -2700,7 +2697,7 @@ void yara_yyset_lineno (int  line_number , yyscan_t yyscanner)
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
            YY_FATAL_ERROR( "yara_yyset_lineno called with no buffer" );
-    
+
     yylineno = line_number;
 }
 
@@ -2715,7 +2712,7 @@ void yara_yyset_column (int  column_no , yyscan_t yyscanner)
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
            YY_FATAL_ERROR( "yara_yyset_column called with no buffer" );
-    
+
     yycolumn = column_no;
 }
 
@@ -2810,20 +2807,20 @@ int yara_yylex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals
         errno = EINVAL;
         return 1;
     }
-	
+
     *ptr_yy_globals = (yyscan_t) yara_yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
-	
+
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
-    
+
     /* By setting to 0xAA, we expose bugs in
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
-    
+
     yara_yyset_extra (yy_user_defined, *ptr_yy_globals);
-    
+
     return yy_init_globals ( *ptr_yy_globals );
 }
 
@@ -2952,7 +2949,7 @@ void yywarning(
 
   char* file_name;
   char message[512];
-  
+
   va_list message_args;
   va_start(message_args, message_fmt);
 
@@ -3107,4 +3104,3 @@ int yr_lex_parse_rules_file(
 
   return compiler->errors;
 }
-

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -27,12 +27,12 @@ limitations under the License.
 #include <openssl/crypto.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #define snprintf _snprintf
 #endif
 
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 DWORD tidx_key;
 DWORD recovery_state_key;
@@ -95,7 +95,7 @@ YR_API int yr_initialize(void)
 
   FAIL_ON_ERROR(yr_heap_alloc());
 
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   tidx_key = TlsAlloc();
   recovery_state_key = TlsAlloc();
   #else
@@ -158,7 +158,7 @@ YR_API int yr_finalize(void)
   OPENSSL_free(locks);
   #endif
 
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   TlsFree(tidx_key);
   TlsFree(recovery_state_key);
   #else
@@ -187,7 +187,7 @@ YR_API int yr_finalize(void)
 
 YR_API void yr_set_tidx(int tidx)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   TlsSetValue(tidx_key, (LPVOID) (tidx + 1));
   #else
   pthread_setspecific(tidx_key, (void*) (size_t) (tidx + 1));
@@ -207,7 +207,7 @@ YR_API void yr_set_tidx(int tidx)
 
 YR_API int yr_get_tidx(void)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   return (int) TlsGetValue(tidx_key) - 1;
   #else
   return (int) (size_t) pthread_getspecific(tidx_key) - 1;

--- a/libyara/mem.c
+++ b/libyara/mem.c
@@ -16,7 +16,7 @@ limitations under the License.
 
 
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 
 #include <windows.h>
 #include <string.h>

--- a/libyara/modules/cuckoo.c
+++ b/libyara/modules/cuckoo.c
@@ -21,7 +21,7 @@ limitations under the License.
 #include <yara/re.h>
 #include <yara/modules.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #define strcasecmp _stricmp
 #endif
 

--- a/libyara/modules/hash.c
+++ b/libyara/modules/hash.c
@@ -17,7 +17,7 @@ limitations under the License.
 #include <openssl/md5.h>
 #include <openssl/sha.h>
 
-#if _WIN32
+#if _WIN32 || __CYGWIN__
 #define PRIu64 "%I64d"
 #define PRIx64 "%I64x"
 #else
@@ -44,10 +44,10 @@ void digest_to_ascii(
 
 
 define_function(string_md5)
-{ 
+{
   unsigned char digest[MD5_DIGEST_LENGTH];
   char digest_ascii[MD5_DIGEST_LENGTH * 2 + 1];
-  
+
   MD5_CTX md5_context;
   SIZED_STRING* s = sized_string_argument(1);
 
@@ -80,7 +80,7 @@ define_function(string_sha256)
 
 
 define_function(string_sha1)
-{ 
+{
   unsigned char digest[SHA_DIGEST_LENGTH];
   char digest_ascii[SHA_DIGEST_LENGTH * 2 + 1];
 
@@ -243,7 +243,7 @@ define_function(data_sha1)
 
 
 define_function(data_sha256)
-{   
+{
   SHA256_CTX sha256_context;
 
   unsigned char digest[SHA256_DIGEST_LENGTH];

--- a/libyara/object.c
+++ b/libyara/object.c
@@ -22,7 +22,7 @@ limitations under the License.
 #include <string.h>
 #include <math.h>
 
-#if _WIN32
+#if _WIN32 || __CYGWIN__
 #define PRIu64 "I64d"
 #else
 #include <inttypes.h>

--- a/libyara/proc.c
+++ b/libyara/proc.c
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 
 #include <windows.h>
 

--- a/libyara/re.c
+++ b/libyara/re.c
@@ -29,7 +29,7 @@ order to avoid confusion with operating system threads.
 #include <string.h>
 #include <limits.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 #else
 #include <pthread.h>
@@ -85,7 +85,7 @@ typedef struct _RE_THREAD_STORAGE
 } RE_THREAD_STORAGE;
 
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 DWORD thread_storage_key = 0;
 #else
 pthread_key_t thread_storage_key = 0;
@@ -100,7 +100,7 @@ pthread_key_t thread_storage_key = 0;
 
 int yr_re_initialize(void)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   thread_storage_key = TlsAlloc();
   #else
   pthread_key_create(&thread_storage_key, NULL);
@@ -118,7 +118,7 @@ int yr_re_initialize(void)
 
 int yr_re_finalize(void)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   TlsFree(thread_storage_key);
   #else
   pthread_key_delete(thread_storage_key);
@@ -142,7 +142,7 @@ int yr_re_finalize_thread(void)
   RE_THREAD_STORAGE* storage;
 
   if (thread_storage_key != 0)
-    #ifdef _WIN32
+    #if defined(_WIN32) || defined(__CYGWIN__)
     storage = (RE_THREAD_STORAGE*) TlsGetValue(thread_storage_key);
     #else
     storage = (RE_THREAD_STORAGE*) pthread_getspecific(thread_storage_key);
@@ -164,7 +164,7 @@ int yr_re_finalize_thread(void)
     yr_free(storage);
   }
 
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   TlsSetValue(thread_storage_key, NULL);
   #else
   pthread_setspecific(thread_storage_key, NULL);
@@ -1184,7 +1184,7 @@ int yr_re_emit_code(
 int _yr_re_alloc_storage(
     RE_THREAD_STORAGE** storage)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   *storage = (RE_THREAD_STORAGE*) TlsGetValue(thread_storage_key);
   #else
   *storage = (RE_THREAD_STORAGE*) pthread_getspecific(thread_storage_key);
@@ -1200,7 +1200,7 @@ int _yr_re_alloc_storage(
     (*storage)->fiber_pool.head = NULL;
     (*storage)->fiber_pool.tail = NULL;
 
-    #ifdef _WIN32
+    #if defined(_WIN32) || defined(__CYGWIN__)
     TlsSetValue(thread_storage_key, *storage);
     #else
     pthread_setspecific(thread_storage_key, *storage);

--- a/libyara/re_lexer.c
+++ b/libyara/re_lexer.c
@@ -34,7 +34,7 @@
 #if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -51,7 +51,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 
@@ -182,7 +182,7 @@ typedef size_t yy_size_t;
 
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
      *       access to the local variable yy_act. Since yyless() is a macro, it would break
-     *       existing scanners that call yyless() from OUTSIDE re_yylex. 
+     *       existing scanners that call yyless() from OUTSIDE re_yylex.
      *       One obvious solution it to make yy_act a global. I tried that, and saw
      *       a 5% performance hit in a non-yylineno scanner, because yy_act is
      *       normally declared as a register variable-- so it is not worth it.
@@ -201,7 +201,7 @@ typedef size_t yy_size_t;
                     if ( *p == '\n' )\
                         --yylineno;\
             }while(0)
-    
+
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
 	do \
@@ -258,7 +258,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -482,7 +482,7 @@ static yyconst flex_int16_t yy_chk[112] =
 /* Table of booleans, true if rule could match eol. */
 static yyconst flex_int32_t yy_rule_can_match_eol[30] =
     {   0,
-0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 
+0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0,     };
 
 /* The intent behind this definition is that it'll catch
@@ -536,10 +536,6 @@ with noyywrap then we can remove this pragma.
 #include <yara/re_lexer.h>
 #include <yara/strutils.h>
 
-
-#ifdef _WIN32
-#define snprintf _snprintf
-#endif
 
 
 uint8_t escaped_char_value(
@@ -609,7 +605,7 @@ static int yy_init_globals (yyscan_t yyscanner );
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
     #    define yylval yyg->yylval_r
-    
+
 int re_yylex_init (yyscan_t* scanner);
 
 int re_yylex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
@@ -866,7 +862,7 @@ yy_find_action:
 			yy_size_t yyl;
 			for ( yyl = 0; yyl < yyleng; ++yyl )
 				if ( yytext[yyl] == '\n' )
-					   
+
     do{ yylineno++;
         yycolumn=0;
     }while(0)
@@ -1727,7 +1723,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	yyg->yy_hold_char = *++yyg->yy_c_buf_p;
 
 	if ( c == '\n' )
-		   
+
     do{ yylineno++;
         yycolumn=0;
     }while(0)
@@ -1810,7 +1806,7 @@ static void re_yy_load_buffer_state  (yyscan_t yyscanner)
     YY_BUFFER_STATE re_yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
-    
+
 	b = (YY_BUFFER_STATE) re_yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in re_yy_create_buffer()" );
@@ -1876,7 +1872,7 @@ static void re_yy_load_buffer_state  (yyscan_t yyscanner)
     }
 
         b->yy_is_interactive = 0;
-    
+
 	errno = oerrno;
 }
 
@@ -1982,9 +1978,9 @@ static void re_yyensure_buffer_stack (yyscan_t yyscanner)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
 			YY_FATAL_ERROR( "out of dynamic memory in re_yyensure_buffer_stack()" );
-								  
+
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		yyg->yy_buffer_stack_max = num_to_alloc;
 		yyg->yy_buffer_stack_top = 0;
 		return;
@@ -2013,12 +2009,12 @@ static void re_yyensure_buffer_stack (yyscan_t yyscanner)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * @param yyscanner The scanner object.
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE re_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
-    
+
 	if ( size < 2 ||
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
@@ -2054,7 +2050,7 @@ YY_BUFFER_STATE re_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yysc
  */
 YY_BUFFER_STATE re_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
 {
-    
+
 	return re_yy_scan_bytes(yystr,strlen(yystr) ,yyscanner);
 }
 
@@ -2071,7 +2067,7 @@ YY_BUFFER_STATE re_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_l
 	char *buf;
 	yy_size_t n;
 	yy_size_t i;
-    
+
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = _yybytes_len + 2;
 	buf = (char *) re_yyalloc(n ,yyscanner );
@@ -2139,10 +2135,10 @@ YY_EXTRA_TYPE re_yyget_extra  (yyscan_t yyscanner)
 int re_yyget_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
-    
+
     return yylineno;
 }
 
@@ -2152,10 +2148,10 @@ int re_yyget_lineno  (yyscan_t yyscanner)
 int re_yyget_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
-    
+
     return yycolumn;
 }
 
@@ -2217,7 +2213,7 @@ void re_yyset_lineno (int  line_number , yyscan_t yyscanner)
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
            YY_FATAL_ERROR( "re_yyset_lineno called with no buffer" );
-    
+
     yylineno = line_number;
 }
 
@@ -2232,7 +2228,7 @@ void re_yyset_column (int  column_no , yyscan_t yyscanner)
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
            YY_FATAL_ERROR( "re_yyset_column called with no buffer" );
-    
+
     yycolumn = column_no;
 }
 
@@ -2327,20 +2323,20 @@ int re_yylex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals )
         errno = EINVAL;
         return 1;
     }
-	
+
     *ptr_yy_globals = (yyscan_t) re_yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
-	
+
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
-    
+
     /* By setting to 0xAA, we expose bugs in
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
-    
+
     re_yyset_extra (yy_user_defined, *ptr_yy_globals);
-    
+
     return yy_init_globals ( *ptr_yy_globals );
 }
 
@@ -2543,7 +2539,7 @@ int read_escaped_char(
 
 
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 extern DWORD recovery_state_key;
 #else
@@ -2557,7 +2553,7 @@ void yyfatal(
 {
   jmp_buf* recovery_state;
 
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   recovery_state = (jmp_buf*) TlsGetValue(recovery_state_key) ;
   #else
   recovery_state = (jmp_buf*) pthread_getspecific(recovery_state_key);
@@ -2601,7 +2597,7 @@ int yr_parse_re_string(
 
   lex_env.last_error_code = ERROR_SUCCESS;
 
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   TlsSetValue(recovery_state_key, (LPVOID) &recovery_state);
   #else
   pthread_setspecific(recovery_state_key, (void*) &recovery_state);
@@ -2635,4 +2631,3 @@ int yr_parse_re_string(
 
   return ERROR_SUCCESS;
 }
-

--- a/libyara/rules.c
+++ b/libyara/rules.c
@@ -41,7 +41,7 @@ limitations under the License.
 void _yr_rules_lock(
     YR_RULES* rules)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   WaitForSingleObject(rules->mutex, INFINITE);
   #else
   pthread_mutex_lock(&rules->mutex);
@@ -52,7 +52,7 @@ void _yr_rules_lock(
 void _yr_rules_unlock(
     YR_RULES* rules)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   ReleaseMutex(rules->mutex);
   #else
   pthread_mutex_unlock(&rules->mutex);
@@ -666,7 +666,7 @@ YR_API int yr_rules_load_stream(
   new_rules->rules_list_head = header->rules_list_head;
   new_rules->tidx_mask = 0;
 
-  #if _WIN32
+  #if _WIN32 || __CYGWIN__
   new_rules->mutex = CreateMutex(NULL, FALSE, NULL);
 
   if (new_rules->mutex == NULL)
@@ -750,7 +750,7 @@ YR_API int yr_rules_destroy(
     external++;
   }
 
-  #if _WIN32
+  #if _WIN32 || __CYGWIN__
   CloseHandle(rules->mutex);
   #else
   pthread_mutex_destroy(&rules->mutex);

--- a/threading.c
+++ b/threading.c
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include <fcntl.h>
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 #include <errno.h>
 #endif
 
@@ -26,7 +26,7 @@ limitations under the License.
 int mutex_init(
     MUTEX* mutex)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   *mutex = CreateMutex(NULL, FALSE, NULL);
   if (*mutex == NULL)
     return GetLastError();
@@ -40,7 +40,7 @@ int mutex_init(
 void mutex_destroy(
     MUTEX* mutex)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   CloseHandle(*mutex);
   #else
   pthread_mutex_destroy(mutex);
@@ -51,7 +51,7 @@ void mutex_destroy(
 void mutex_lock(
     MUTEX* mutex)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   WaitForSingleObject(*mutex, INFINITE);
   #else
   pthread_mutex_lock(mutex);
@@ -62,7 +62,7 @@ void mutex_lock(
 void mutex_unlock(
     MUTEX* mutex)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   ReleaseMutex(*mutex);
   #else
   pthread_mutex_unlock(mutex);
@@ -74,7 +74,7 @@ int semaphore_init(
     SEMAPHORE* semaphore,
     int value)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   *semaphore = CreateSemaphore(NULL, value, 65535, NULL);
   if (*semaphore == NULL)
     return GetLastError();
@@ -100,7 +100,7 @@ int semaphore_init(
 void semaphore_destroy(
     SEMAPHORE* semaphore)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   CloseHandle(*semaphore);
   #else
   sem_close(*semaphore);
@@ -111,7 +111,7 @@ void semaphore_destroy(
 void semaphore_wait(
     SEMAPHORE* semaphore)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   WaitForSingleObject(*semaphore, INFINITE);
   #else
   sem_wait(*semaphore);
@@ -122,9 +122,9 @@ void semaphore_wait(
 void semaphore_release(
     SEMAPHORE* semaphore)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   ReleaseSemaphore(*semaphore, 1, NULL);
-  #else   
+  #else
   sem_post(*semaphore);
   #endif
 }
@@ -135,7 +135,7 @@ int create_thread(
     THREAD_START_ROUTINE start_routine,
     void* param)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   *thread = CreateThread(NULL, 0, start_routine, param, 0, NULL);
   if (*thread == NULL)
     return GetLastError();
@@ -150,7 +150,7 @@ int create_thread(
 void thread_join(
     THREAD* thread)
 {
-  #ifdef _WIN32
+  #if defined(_WIN32) || defined(__CYGWIN__)
   WaitForSingleObject(*thread, INFINITE);
   #else
   pthread_join(*thread, NULL);

--- a/threading.h
+++ b/threading.h
@@ -18,7 +18,7 @@ limitations under the License.
 #ifndef YR_THREADING_H
 #define YR_THREADING_H
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #include <windows.h>
 #else
 #include <sys/stat.h>
@@ -26,7 +26,7 @@ limitations under the License.
 #include <semaphore.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 
 typedef HANDLE SEMAPHORE;
 typedef HANDLE MUTEX;

--- a/windows/include/jansson.h
+++ b/windows/include/jansson.h
@@ -54,7 +54,7 @@ typedef struct json_t {
 
 #ifndef JANSSON_USING_CMAKE /* disabled if using cmake */
 #if JSON_INTEGER_IS_LONG_LONG
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #define JSON_INTEGER_FORMAT "I64d"
 #else
 #define JSON_INTEGER_FORMAT "lld"

--- a/yara.c
+++ b/yara.c
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 
 #include <sys/stat.h>
 #include <dirent.h>
@@ -273,7 +273,7 @@ char* file_queue_get()
 }
 
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 
 int is_directory(
     const char* path)
@@ -403,7 +403,7 @@ void print_string(
 }
 
 
-static char cescapes[] = 
+static char cescapes[] =
 {
   0  , 0  , 0  , 0  , 0  , 0  , 0  , 'a',
   'b', 't', 'n', 'v', 'f', 'r', 0  , 0  ,
@@ -427,15 +427,15 @@ void print_escaped(
       case '\\':
         printf("\\%c", data[i]);
         break;
-  
+
       default:
-        if (data[i] >= 127) 
+        if (data[i] >= 127)
           printf("\\%03o", data[i]);
         else if (data[i] >= 32)
           putchar(data[i]);
-        else if (cescapes[data[i]] != 0) 
+        else if (cescapes[data[i]] != 0)
           printf("\\%c", cescapes[data[i]]);
-        else 
+        else
           printf("\\%03o", data[i]);
     }
   }
@@ -508,8 +508,8 @@ void print_compiler_error(
 
 
 int handle_message(
-    int message, 
-    YR_RULE* rule, 
+    int message,
+    YR_RULE* rule,
     void* data)
 {
   const char* tag;
@@ -602,7 +602,7 @@ int handle_message(
         {
           printf("%s=%s", meta->identifier, meta->integer ? "true" : "false");
         }
-        else 
+        else
         {
           printf("%s=\"", meta->identifier);
           print_escaped((uint8_t*) (meta->string), strlen(meta->string));
@@ -653,8 +653,8 @@ int handle_message(
 
 
 int callback(
-    int message, 
-    void* message_data, 
+    int message,
+    void* message_data,
     void* user_data)
 {
   YR_MODULE_IMPORT* mi;
@@ -707,7 +707,7 @@ int callback(
 }
 
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 DWORD WINAPI scanning_thread(LPVOID param)
 #else
 void* scanning_thread(void* param)

--- a/yarac.c
+++ b/yarac.c
@@ -270,4 +270,3 @@ _exit:
 
   return result;
 }
-


### PR DESCRIPTION
Cygwin does not define _WIN32 but instead uses __CYGWIN__. Additionally under cygwin you have all the usual posix functions like snprinf so the parts of strutils.h which define macro aliases are not needed.