### PR TITLE
Split text and hex strings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,8 +15,10 @@ yarac_SOURCES = args.c args.h yarac.c
 yarac_LDADD = libyara/.libs/libyara.a
 
 TESTS = $(check_PROGRAMS)
-check_PROGRAMS = test-alignment
+check_PROGRAMS = test-alignment test-syntax
 test_alignment_SOURCES = tests/test-alignment.c
+test_syntax_SOURCES = tests/test-syntax.c
+test_syntax_LDADD = libyara/.libs/libyara.la
 
 # man pages
 man1_MANS = yara.man yarac.man

--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -155,6 +155,7 @@ limitations under the License.
 %type <c_string> tags
 %type <c_string> tag_list
 
+%type <sized_string> text_string
 %type <integer> string_modifier
 %type <integer> string_modifiers
 
@@ -472,13 +473,26 @@ string_declarations
     | string_declarations string_declaration  { $$ = $1; }
     ;
 
+text_string
+    : _TEXT_STRING_               { $$ = $1; }
+    | _TEXT_STRING_ _TEXT_STRING_
+      {
+        $$ = yr_malloc(sizeof(SIZED_STRING) + $1->length + $2->length + 1);
+        $$->flags = 0;
+        $$->c_string[0] = 0;
+        strcat($$->c_string, $1->c_string);
+        strcat($$->c_string, $2->c_string);
+        $$->length = $1->length + $2->length;
+      }
+    ;
+
 
 string_declaration
     : _STRING_IDENTIFIER_ '='
       {
         compiler->error_line = yyget_lineno(yyscanner);
       }
-      _TEXT_STRING_ string_modifiers
+      text_string string_modifiers
       {
         $$ = yr_parser_reduce_string_declaration(
             yyscanner, (int32_t) $5, $1, $4);

--- a/libyara/hex_grammar.y
+++ b/libyara/hex_grammar.y
@@ -91,10 +91,10 @@ limitations under the License.
 %%
 
 hex_string
-    : '{' tokens '}'
+    : tokens
       {
         RE* re = yyget_extra(yyscanner);
-        re->root_node = $2;
+        re->root_node = $1;
       }
     ;
 

--- a/libyara/lexer.l
+++ b/libyara/lexer.l
@@ -84,6 +84,9 @@ with noyywrap then we can remove this pragma.
 #define snprintf _snprintf
 #endif
 
+  /* If non-zero, '{' starts a hexadecimal string */
+  int strings_context = 0;
+
 %}
 
 %option reentrant bison-bridge
@@ -100,6 +103,7 @@ with noyywrap then we can remove this pragma.
 %option warn
 
 %x str
+%x hex_str
 %x regexp
 %x include
 %x comment
@@ -574,6 +578,20 @@ u?int(8|16|32)(be)? {
   yyterminate();
 }
 
+<hex_str>({hexdigit}|[ \-|\?\[\]\(\)\n\t])+ { YYTEXT_TO_BUFFER; }
+
+<hex_str>\} { /* closing brace */
+  ALLOC_SIZED_STRING(s, yyextra->lex_buf_len);
+
+  *yyextra->lex_buf_ptr = '\0';
+  memcpy(s->c_string, yyextra->lex_buf, yyextra->lex_buf_len + 1);
+  yylval->sized_string = s;
+
+  BEGIN(INITIAL);
+
+  return _HEX_STRING_;
+}
+
 
 \"  {
 
@@ -591,14 +609,13 @@ u?int(8|16|32)(be)? {
 }
 
 
-\{({hexdigit}|[ \-|\?\[\]\(\)\n\t])+\}  {
-
-  ALLOC_SIZED_STRING(s, strlen(yytext));
-
-  strlcpy(s->c_string, yytext, s->length + 1);
-  yylval->sized_string = s;
-
-  return _HEX_STRING_;
+\{ {
+  if (!strings_context) {
+    return '{';
+  }
+  yyextra->lex_buf_ptr = yyextra->lex_buf;
+  yyextra->lex_buf_len = 0;
+  BEGIN(hex_str);
 }
 
 

--- a/tests/regular-hex.yar
+++ b/tests/regular-hex.yar
@@ -1,0 +1,6 @@
+rule t {
+strings:
+  $hex = { 31 32 33 34 }
+condition:
+  all of them
+}

--- a/tests/regular-string.yar
+++ b/tests/regular-string.yar
@@ -1,0 +1,6 @@
+rule t {
+strings:
+  $str = "1234"
+condition:
+  all of them
+}

--- a/tests/split-hex1.yar
+++ b/tests/split-hex1.yar
@@ -1,0 +1,7 @@
+rule t {
+strings:
+  $hex = { 31 32 }
+         { 33 34 }
+condition:
+  all of them
+}

--- a/tests/split-hex2.yar
+++ b/tests/split-hex2.yar
@@ -1,0 +1,6 @@
+rule t {
+strings:
+  $hex = { 41 42 } /* comment */ { 43 44 }
+condition:
+  all of them
+}

--- a/tests/split-hex3.yar
+++ b/tests/split-hex3.yar
@@ -1,0 +1,7 @@
+rule t {
+strings:
+  $hex = { 61 62 } // comment
+         { 63 64 }
+condition:
+  all of them
+}

--- a/tests/split-string1.yar
+++ b/tests/split-string1.yar
@@ -1,0 +1,6 @@
+rule t {
+strings:
+  $str = "12" "34"
+condition:
+  all of them
+}

--- a/tests/split-string2.yar
+++ b/tests/split-string2.yar
@@ -1,0 +1,6 @@
+rule t {
+strings:
+  $str = "AB" /* comment */ "CD"
+condition:
+  all of them
+}

--- a/tests/split-string3.yar
+++ b/tests/split-string3.yar
@@ -1,0 +1,7 @@
+rule t {
+strings:
+  $str = "ab" // comment
+         "cd"
+condition:
+  all of them
+}

--- a/tests/test-syntax.c
+++ b/tests/test-syntax.c
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2016. The YARA Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <yara.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+void compile_callback(int error_level,
+                      const char* file_name,
+                      int line_number,
+                      const char* message,
+                      void* user_data) {
+  printf("compile: %s:%d: %s\n", file_name, line_number, message);
+}
+
+int scan_callback(int message, void* message_data, void* user_data) {
+  if (message == CALLBACK_MSG_RULE_MATCHING) {
+    (*((int*)user_data))++;
+  }
+  return CALLBACK_CONTINUE;
+}
+
+int test_rule(char* rulefile, char* positive, char* negative) {
+  YR_COMPILER *c;
+  printf("Compiling %s ...\n", rulefile);
+  FILE* f = fopen(rulefile, "r");
+  if (f == NULL) {
+    printf("fopen: %s: %s\n", rulefile, strerror(errno));
+    return -1;
+  }
+  yr_compiler_create(&c);
+  yr_compiler_set_callback(c, compile_callback, NULL);
+  int error = -1;
+  if (yr_compiler_add_file(c, f, NULL, rulefile) != 0) {
+    printf("compile failed\n");
+    goto out1;
+  }
+  YR_RULES *r;
+  if (yr_compiler_get_rules(c, &r) != 0) {
+    printf("yr_compiler_get_rules failed\n");
+    goto out1;
+  }
+  int nmatches = 0;
+  if (yr_rules_scan_mem(r, (unsigned char*)positive, strlen(positive), 0,
+                        scan_callback, &nmatches, 0) == ERROR_SUCCESS) {
+    if (nmatches == 0) {
+      printf("Error: did not match <%s>\n", positive);
+      goto out2;
+    }
+    printf("Ok: matched <%s>\n", positive);
+
+  } else {
+    printf("yr_rules_scan_mem: error\n");
+    goto out2;
+  }
+  nmatches = 0;
+  if (yr_rules_scan_mem(r, (unsigned char*)negative, strlen(negative), 0,
+                        scan_callback, &nmatches, 0) == ERROR_SUCCESS) {
+    if (nmatches > 0) {
+      printf("Error: matched <%s>\n", negative);
+      goto out2;
+    }
+    printf("Ok: did not match <%s>\n", negative);
+  } else {
+    printf("yr_rules_scan_mem: error\n");
+    goto out2;
+  }
+
+  error = 0;
+ out2:
+  yr_rules_destroy(r);
+ out1:
+  fclose(f);
+  yr_compiler_destroy(c);
+  return error;
+}
+
+int main (int argc, char **argv) {
+  yr_initialize();
+  int error = 0;
+
+  error += test_rule("tests/regular-string.yar", "1234", "3412");
+  error += test_rule("tests/split-string1.yar", "1234", "3412");
+  error += test_rule("tests/split-string2.yar", "ABCD", "CDAB");
+  error += test_rule("tests/split-string3.yar", "abcd", "cdab");
+  error += test_rule("tests/regular-hex.yar", "1234", "3412");
+  error += test_rule("tests/split-hex1.yar", "1234", "3412");
+  error += test_rule("tests/split-hex2.yar", "ABCD", "CDAB");
+  error += test_rule("tests/split-hex3.yar", "abcd", "cdab");
+
+  if (error != 0) {
+    return 1;
+  }
+}


### PR DESCRIPTION
When writing rules that are based upon disassembler output, I would like to be able to sprinkle 
bits of text produced by the used tool (e.g. IDA Pro) as comments between the hex strings.

The proposed change is inspired by the way C understands `"abcd" "ef"` just like `"abcdef"`.