### PR TITLE
Add support for VS2015 as a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,12 @@ stamp-h1
 # Linux and Mac files
 *.swp
 .DS_Store
+
+# Visual Studio files
+Release/
+Debug/
+x64/
+*.obj
+*.suo
+*.sdf
+*.opensdf

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "windows/yara-VS2015"]
+	path = windows/yara-VS2015
+	url = https://github.com/kallanreed/yara-VS2015.git

--- a/libyara/include/yara/strutils.h
+++ b/libyara/include/yara/strutils.h
@@ -25,7 +25,9 @@ limitations under the License.
 
 // Cygwin already has these functions.
 #if defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #endif

--- a/libyara/libyara.c
+++ b/libyara/libyara.c
@@ -47,6 +47,43 @@ static int init_count = 0;
 char lowercase[256];
 char altercase[256];
 
+#ifndef HAVE_PTHREAD
+#ifdef _WIN32
+
+typedef HANDLE pthread_mutex_t;
+
+unsigned long pthread_self()
+{
+    return GetCurrentThreadId();
+}
+
+int pthread_mutex_init(pthread_mutex_t *mutex, void* attr)
+{
+    *mutex = CreateSemaphore(NULL, 1, 1, NULL);
+    return *mutex == NULL;
+}
+
+int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+    BOOL result;
+
+    result = CloseHandle(*mutex);
+    *mutex = NULL;
+    return result == TRUE ? 0 : -1;
+}
+
+int pthread_mutex_lock(pthread_mutex_t mutex)
+{
+    return WaitForSingleObject(mutex, INFINITE) == WAIT_OBJECT_0 ? 0 : -1;
+}
+
+int pthread_mutex_unlock(pthread_mutex_t mutex)
+{
+    return ReleaseSemaphore(mutex, 1, NULL) == TRUE ? 0 : -1;
+}
+#endif
+#endif
+
 #ifdef HAVE_LIBCRYPTO
 pthread_mutex_t *locks;
 
@@ -104,7 +141,7 @@ YR_API int yr_initialize(void)
   #endif
 
   #ifdef HAVE_LIBCRYPTO
-  locks = OPENSSL_malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t));
+  locks = (pthread_mutex_t*)OPENSSL_malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t));
   for (i = 0; i < CRYPTO_num_locks(); i++)
     pthread_mutex_init(&locks[i], NULL);
 

--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -1838,7 +1838,7 @@ define_function(locale)
 define_function(language)
 {
   YR_OBJECT* module = module();
-  PE* pe = module->data;
+  PE* pe = (PE*)module->data;
 
   uint64_t language = integer_argument(1);
   int64_t n, i;
@@ -1881,7 +1881,7 @@ define_function(is_dll)
 define_function(is_32bit)
 {
   YR_OBJECT* module = module();
-  PE* pe = module->data;
+  PE* pe = (PE*)module->data;
 
   if (pe == NULL)
     return_integer(UNDEFINED);
@@ -1893,7 +1893,7 @@ define_function(is_32bit)
 define_function(is_64bit)
 {
   YR_OBJECT* module = module();
-  PE* pe = module->data;
+  PE* pe = (PE*)module->data;
 
   if (pe == NULL)
     return_integer(UNDEFINED);

--- a/libyara/parser.c
+++ b/libyara/parser.c
@@ -468,7 +468,7 @@ YR_STRING* yr_parser_reduce_string_declaration(
   // Determine if a string with the same identifier was already defined
   // by searching for the identifier in string_table.
 
-  string = yr_hash_table_lookup(
+  string = (YR_STRING*)yr_hash_table_lookup(
       compiler->strings_table,
       identifier,
       NULL);

--- a/windows/BUILDING.md
+++ b/windows/BUILDING.md
@@ -16,7 +16,7 @@ The core yara project include binary libs (`jansson` and `libeay`) compiled with
 
 VS2015 projects are included as a submodule that must be downloaded manually. To download the VS2015 project, run the following git command
 
-  git submodule update --init windows/yara-VS2015
+    git submodule update --init windows/yara-VS2015
 
 This will unpack the submodule into `yara/windows/yara-VS2015`. Open the `yara/windows/yara-VS2015/yara-2015.sln` and build as normal.
 

--- a/windows/BUILDING.md
+++ b/windows/BUILDING.md
@@ -1,0 +1,2 @@
+# Building YARA with Visual Studio
+

--- a/windows/BUILDING.md
+++ b/windows/BUILDING.md
@@ -4,13 +4,13 @@
 
 In an effort to make Windows development a little easier, Visual Studio solutions are included under the `yara/windows` directory. The current project has binary dependencies checked into the repo, but this is not a good strategy long term. As build tools are updated and old versions are deprecated, there needed to be a more maintainable solution that didn't cause binary bloat in the repo.
 
-Support for new versions of Visual Studio should be added as submodules. This allows the binary dependencies to exist outide of the main repo and also makes downloading the projects optional.
+Support for new versions of Visual Studio should be added as submodules. This allows the binary dependencies to exist outside of the main repo and also makes downloading the specific projects optional.
 
 ## Quick Start VS2010 (legacy)
 
-The core yara project include binary libs (`jansson` and `libeay`) compiled with VS2010. To build the project, simply open up the `yara/windows/yara/ara.sln` and build thr project.
+The core yara project includes binary libs (`jansson` and `libeay`) compiled with VS2010. To build the project, simply open up the `yara/windows/yara/ara.sln` and build the project.
 
-*Do not check in *upgrades* to the solution or project files and do not check in binary updates to this repo. The 2010 tool chain is included in the repo because it was added before the decision to separate out support for VS versions. To support new versions of Visual Studio, add a submodule instead.*
+_Do not check in *upgrades* to the solution or project files and do not check in binary updates to this repo. The 2010 tool chain is included in the repo because it was added before the decision to separate out support for VS versions. To support new versions of Visual Studio, add a submodule instead._
 
 ## Quick Start VS2015
 
@@ -28,4 +28,4 @@ You can use other versions of Visual Studio as long as you have the VS2010 tool 
 
 ## Dependencies
 
-The Windows version of yara requires OpenSLL and JSON libraries. These can be built from source or you can reference the tool-chain specific binaries in the `lib` folder.i
+The Windows version of yara requires OpenSLL and JSON libraries. These can be built from source or you can reference the tool-chain specific binaries in the `lib` folder.

--- a/windows/BUILDING.md
+++ b/windows/BUILDING.md
@@ -1,2 +1,31 @@
 # Building YARA with Visual Studio
 
+**Do not check in upgraded versions of the solution, the projects or any rebuilt lib binaries.**
+
+In an effort to make Windows development a little easier, Visual Studio solutions are included under the `yara/windows` directory. The current project has binary dependencies checked into the repo, but this is not a good strategy long term. As build tools are updated and old versions are deprecated, there needed to be a more maintainable solution that didn't cause binary bloat in the repo.
+
+Support for new versions of Visual Studio should be added as submodules. This allows the binary dependencies to exist outide of the main repo and also makes downloading the projects optional.
+
+## Quick Start VS2010 (legacy)
+
+The core yara project include binary libs (`jansson` and `libeay`) compiled with VS2010. To build the project, simply open up the `yara/windows/yara/ara.sln` and build thr project.
+
+*Do not check in *upgrades* to the solution or project files and do not check in binary updates to this repo. The 2010 tool chain is included in the repo because it was added before the decision to separate out support for VS versions. To support new versions of Visual Studio, add a submodule instead.*
+
+## Quick Start VS2015
+
+VS2015 projects are included as a submodule that must be downloaded manually. To download the VS2015 project, run the following git command
+
+  git submodule update --init windows/yara-VS2015
+
+This will unpack the submodule into `yara/windows/yara-VS2015`. Open the `yara/windows/yara-VS2015/yara-2015.sln` and build as normal.
+
+Read the included README for information on keeping the submodule updated and how to submit changes to the `yara-VS2015` project.
+
+## Other versions
+
+You can use other versions of Visual Studio as long as you have the VS2010 tool chain installed. Do not upgrade the project files and do not check in modificaitions to the solution or the project files.
+
+## Dependencies
+
+The Windows version of yara requires OpenSLL and JSON libraries. These can be built from source or you can reference the tool-chain specific binaries in the `lib` folder.i


### PR DESCRIPTION
After a long conversation about the best way to add VS2015 support in #377, we came to the conclusion that updating binaries in repo wasn't a good long term solution but neither was having to sort out dependencies just to get the project to build.

This is the compromise. New VS version support added via a submodule should keep the core repo light while still providing a decent pull and build story on Windows.

I added a build readme for Windows with instructions on how to pull the submodule. The submodule itself contains the project and binaries needed to compile. I also cleaned up the project files in the new repo. This change also includes PR #408.

The submodule is currently pointing to a repo I manage, but that can be moved under `plusvic` if that's desirable.