### PR TITLE
Accept signed numbers (integers, doubles)

### DIFF
--- a/libyara/grammar.y
+++ b/libyara/grammar.y
@@ -438,6 +438,19 @@ meta_declaration
 
         ERROR_IF($$ == NULL);
       }
+    | _IDENTIFIER_ '=' '-' _NUMBER_
+      {
+        $$ = yr_parser_reduce_meta_declaration(
+            yyscanner,
+            META_TYPE_INTEGER,
+            $1,
+            NULL,
+            -$4);
+
+        yr_free($1);
+
+        ERROR_IF($$ == NULL);
+      }
     | _IDENTIFIER_ '=' _TRUE_
       {
         $$ = yr_parser_reduce_meta_declaration(


### PR DESCRIPTION
From what I can see, `_NUMBER_` tokens are used in meta declarations, (grammar.y:428) and primary expressions (grammar.y:1567). In both cases, an int64_t is used to store the value, so the sign can be preserved.

`_DOUBLE_` tokens are used in primary expressions (grammar.y:1577), the same applies here.

After the changes in this PR, the following works as expected:
<pre>
$ cat t.yar
rule t1 { meta: myint = +7 condition: true }
rule t2 { meta: myint =  7 condition: true }
rule t3 { meta: myint = -7 condition: true }
rule t4 { condition: -1.0 > -2.0 }
$ ./yara -m t.yar /dev/null 
debug enabledt1 [myint=7] /dev/null
t2 [myint=7] /dev/null
t3 [myint=-7] /dev/null
t4 [] /dev/null
</pre>