### PR TITLE
Split strings, hex-strings

### DIFF
--- a/libyara/hex_grammar.y
+++ b/libyara/hex_grammar.y
@@ -91,10 +91,10 @@ limitations under the License.
 %%
 
 hex_string
-    : '{' tokens '}'
+    : tokens
       {
         RE* re = yyget_extra(yyscanner);
-        re->root_node = $2;
+        re->root_node = $1;
       }
     ;
 

--- a/libyara/lexer.l
+++ b/libyara/lexer.l
@@ -84,6 +84,9 @@ with noyywrap then we can remove this pragma.
 #define snprintf _snprintf
 #endif
 
+  /* If non-zero, '{' starts a hexadecimal string */
+  extern int inside_rule_body;
+
 %}
 
 %option reentrant bison-bridge
@@ -100,6 +103,7 @@ with noyywrap then we can remove this pragma.
 %option warn
 
 %x str
+%x hex_str
 %x regexp
 %x include
 %x comment
@@ -574,6 +578,20 @@ u?int(8|16|32)(be)? {
   yyterminate();
 }
 
+<hex_str>({hexdigit}|[ \-|\?\[\]\(\)\n\t])+ { YYTEXT_TO_BUFFER; }
+
+<hex_str>\} { /* closing brace */
+  ALLOC_SIZED_STRING(s, yyextra->lex_buf_len);
+
+  *yyextra->lex_buf_ptr = '\0';
+  memcpy(s->c_string, yyextra->lex_buf, yyextra->lex_buf_len + 1);
+  yylval->sized_string = s;
+
+  BEGIN(INITIAL);
+
+  return _HEX_STRING_;
+}
+
 
 \"  {
 
@@ -591,14 +609,13 @@ u?int(8|16|32)(be)? {
 }
 
 
-\{({hexdigit}|[ \-|\?\[\]\(\)\n\t])+\}  {
-
-  ALLOC_SIZED_STRING(s, strlen(yytext));
-
-  strlcpy(s->c_string, yytext, s->length + 1);
-  yylval->sized_string = s;
-
-  return _HEX_STRING_;
+\{ {
+  if (!inside_rule_body) {
+    return '{';
+  }
+  yyextra->lex_buf_ptr = yyextra->lex_buf;
+  yyextra->lex_buf_len = 0;
+  BEGIN(hex_str);
 }
 
 

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -1270,6 +1270,41 @@ condition:\n\
 }
 
 
+void test_split_hex()
+{
+  char* h1 = "rule test { strings: $a = { 31 32 } { 33 34 } condition: $a }";
+  char* h2 = "rule test { strings: $a = { 31 32 } /* comment */ { 33 34 } condition: $a }";
+  char* h3 = "\
+rule test {\n\
+strings:\n\
+  $a = { 31 32 } // comment\n\
+       { 33 34 }\n\
+condition:\n\
+  $a\n\
+}";
+
+  assert_syntax_correct(h1);
+  assert_syntax_correct(h2);
+  assert_syntax_correct(h3);
+
+  assert_true_rule(h1, "1234");
+  assert_true_rule(h2, "1234");
+  assert_true_rule(h3, "1234");
+
+  assert_false_rule(h1, "3412");
+  assert_false_rule(h2, "3412");
+  assert_false_rule(h3, "3412");
+
+  assert_false_rule(h1, "12");
+  assert_false_rule(h2, "12");
+  assert_false_rule(h3, "12");
+
+  assert_false_rule(h1, "34");
+  assert_false_rule(h2, "34");
+  assert_false_rule(h3, "34");
+}
+
+
 int main(int argc, char** argv)
 {
   yr_initialize();
@@ -1305,6 +1340,7 @@ int main(int argc, char** argv)
   // test_string_io();
   test_entrypoint();
   test_split_strings();
+  test_split_hex();
 
   yr_finalize();
 

--- a/tests/test-rules.c
+++ b/tests/test-rules.c
@@ -1235,6 +1235,41 @@ void test_integer_functions()
 }
 
 
+void test_split_strings()
+{
+  char* s1 = "rule test { strings: $a = \"12\" \"34\" condition: $a }";
+  char* s2 = "rule test { strings: $a = \"12\" /* comment */ \"34\" condition: $a }";
+  char* s3 = "\
+rule test {\n\
+strings:\n\
+  $a = \"12\" // comment\n\
+       \"34\"\n\
+condition:\n\
+  $a\n\
+}";
+
+  assert_syntax_correct(s1);
+  assert_syntax_correct(s2);
+  assert_syntax_correct(s3);
+
+  assert_true_rule(s1, "1234");
+  assert_true_rule(s2, "1234");
+  assert_true_rule(s3, "1234");
+
+  assert_false_rule(s1, "3412");
+  assert_false_rule(s2, "3412");
+  assert_false_rule(s3, "3412");
+
+  assert_false_rule(s1, "12");
+  assert_false_rule(s2, "12");
+  assert_false_rule(s3, "12");
+
+  assert_false_rule(s1, "34");
+  assert_false_rule(s2, "34");
+  assert_false_rule(s3, "34");
+}
+
+
 int main(int argc, char** argv)
 {
   yr_initialize();
@@ -1269,6 +1304,7 @@ int main(int argc, char** argv)
   test_integer_functions();
   // test_string_io();
   test_entrypoint();
+  test_split_strings();
 
   yr_finalize();
 


### PR DESCRIPTION
This series of commits extends the grammar (and in the case of hex strings) the lexer to accept strings and hex strings that are be split into multiple tokens, possibly with interwoven comments.

For hex strings, this is particularly useful because it is now possible to mix bytes with assembly mnemonics or annotated hex dumps.

For example:

    $str = "foo" "bar" "baz"
    $str = "foo" /* a comment */ "bar" // another comment
           "baz"
    $hex = { 66 6f 6f } { 62 61 72 }
           { 62 61 7a }
    $hex = { 66 6f 6f } /* a comment */ { 62 61 72 } // another comment
           { 62 61 7a }
