### PR TITLE
Fix RVA calculation corner cases.

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -395,6 +395,13 @@ int64_t pe_rva_to_offset(
         section_rva = section->VirtualAddress;
         section_offset = section->PointerToRawData;
         section_raw_size = section->SizeOfRawData;
+
+        // If the section_offset is less than 0x200 it is rounded down to 0.
+        // See also: https://github.com/plusvic/yara/issues/399
+        // Discussion (and other awesome details) at:
+        // https://code.google.com/archive/p/corkami/wikis/PE.wiki#PointerToRawData
+        if (section_offset < 0x200)
+          section_offset = 0;
       }
 
       section++;


### PR DESCRIPTION
When the PointerToRawData is less than 0x200 it is rounded down to 0x00. This
causes entry point calculation to be incorrect in some cases. For example, these
two issues highlight the problem:

https://github.com/plusvic/yara/issues/399
https://github.com/plusvic/yara/issues/373

Details of this are in
https://code.google.com/archive/p/corkami/wikis/PE.wiki#PointerToRawData

I tested this against 293 PE files and found one difference in entry point
calculation, which upon inspection turned out to be another case of this bug.

Fixes: #399
Fixes: #373