### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libjansson-dev libmagic-dev libssl-dev autoconf automake libtool
+
+before_script: ./bootstrap.sh
+script: ./configure && make && make check
+
+language: c


### PR DESCRIPTION
Note that the test currently fails due to a regression introduced by merging PR #420. (This is exactly the type of regression that a CI setup might prevent from happening in the future.)