### PR TITLE
pe: Recognize RVAs below mapped sections

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -886,7 +886,7 @@ IMPORTED_FUNCTION* pe_parse_import_descriptor(
   // I've seen binaries where OriginalFirstThunk is zero. In this case
   // use FirstThunk.
 
-  if (offset < 0)
+  if (offset <= 0)
     offset = pe_rva_to_offset(pe, import_descriptor->FirstThunk);
 
   if (offset < 0)


### PR DESCRIPTION
Closes #379, #395 

Should we also add test data for this?