### PR TITLE
Removed exclusion of period-prefixed directories in recursive directory scan

### DIFF
--- a/yara.c
+++ b/yara.c
@@ -318,7 +318,7 @@ void scan_dir(
       {
         file_queue_put(full_path);
       }
-      else if (recursive && FindFileData.cFileName[0] != '.' )
+      else if (recursive && strcmp(FindFileData.cFileName, ".") != 0 && strcmp(FindFileData.cFileName, "..") != 0)
       {
         scan_dir(full_path, recursive, start_time, rules, callback);
       }
@@ -374,7 +374,8 @@ void scan_dir(
         else if(recursive &&
                 S_ISDIR(st.st_mode) &&
                 !S_ISLNK(st.st_mode) &&
-                de->d_name[0] != '.')
+                strcmp(de->d_name, ".") != 0 &&
+                strcmp(de->d_name, "..") != 0)
         {
           scan_dir(full_path, recursive, start_time, rules, callback);
         }


### PR DESCRIPTION
The recursive directory scan currently excludes any directories for which the first character is a period. This is obviously so that the standard "." and ".." directory entries are not scanned, however this has the unwanted side-effect of excluding any directory that begins with a period - the equivalent of a "hidden" directory on a Linux box. This has caused a few issues where malicious files in period-prefixed directories do not get picked up.

A small edit, but by changing the current comparison to using strcmp() to check for either "." or "..", we can still exclude those standard directories, but retain the ability to scan any other directory beginning with a period.