### PR TITLE
pe: rva_to_offset: Stay within bounds if no valid sections are found

### DIFF
--- a/libyara/modules/pe.c
+++ b/libyara/modules/pe.c
@@ -441,7 +441,9 @@ int64_t pe_rva_to_offset(
 
   if (rva < lowest_section_rva)
   {
-    return rva;
+    section_rva = 0;
+    section_offset = 0;
+    section_raw_size = pe->data_size;
   }
 
   // Many sections, have a raw (on disk) size smaller than their in-memory size.


### PR DESCRIPTION
out-of-bounds reads in pe_valid_dll_name() due to an invalid offset
could lead to segmentation faults for some malformed PE files.