### PR TITLE
Add 32-bit build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
+dist: trusty
+sudo: required
 install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libjansson-dev libmagic-dev libssl-dev autoconf automake libtool
+  - sudo dpkg --add-architecture i386
+  # Not all repositories contain i386 binary packages
+  - sudo rm -rf /etc/apt/sources.list.d/
+  - sudo apt-get update
+  - sudo apt-get install -y gcc-multilib autoconf automake libtool libjansson-dev libmagic-dev libssl-dev
 
 before_script: ./bootstrap.sh
 script: ./configure && make && make check
 
 language: c
+env:
+  - CFLAGS=-m64
+  - CFLAGS=-m32

--- a/tests/test-alignment.c
+++ b/tests/test-alignment.c
@@ -22,7 +22,7 @@ int err = 0;
 #define CHECK_SIZE(expr,size)                          \
   do                                                   \
   {                                                    \
-    printf("sizeof("#expr") = %lu ...", sizeof(expr)); \
+    printf("sizeof("#expr") = %zd ...", sizeof(expr)); \
     if (sizeof(expr) == size)                          \
     {                                                  \
       puts("ok");                                      \
@@ -37,7 +37,7 @@ int err = 0;
 #define CHECK_OFFSET(expr,offset,subexpr)             \
   do                                                  \
   {                                                   \
-    printf("offsetof("#expr", "#subexpr") = %lu ...", \
+    printf("offsetof("#expr", "#subexpr") = %zd ...", \
            offsetof(expr, subexpr));                  \
     if (offsetof(expr, subexpr) == offset)            \
     {                                                 \


### PR DESCRIPTION
This demonstrates the #450 regression quite nicely.

I haven't been able to figure out if it is possible to install 32bit versions of the optional libraries (`libmagic`, `libssl`, `libjansson` yet, but they're there for the 64bit build.